### PR TITLE
Refactor SVG to Separate Component and Cleanup Imports

### DIFF
--- a/src/client/components/TestimonialsPage/TestimonialsCardStack/TestimonialsCardStack.tsx
+++ b/src/client/components/TestimonialsPage/TestimonialsCardStack/TestimonialsCardStack.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
-import EmployeeCardStack from '../../TestimonialsCardStack/TestimonialsCardStack';
+import EmployeeCardStack from '../../EmployeeCardStack/EmployeeCardStack';
 import styles from './TestimonialsCardStack.scss';
+import StarSvg from '../StarSvg/StarSvg';
 
 const TestimonialsCardStack: React.FunctionComponent = () => {
-  const starSvg = (
-    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path fillRule="evenodd" clipRule="evenodd" d="M14.3834 4.28C14.9807 2.844 17.018 2.844 17.6154 4.28L20.3914 10.956L27.5967 11.5333C29.1487 11.6573 29.778 13.5933 28.5954 14.6067L23.106 19.3093L24.782 26.34C25.1434 27.8547 23.4967 29.0507 22.1687 28.24L15.9994 24.472L9.83002 28.24C8.50202 29.0507 6.85535 27.8533 7.21669 26.34L8.89269 19.3093L3.40335 14.6067C2.22069 13.5933 2.85002 11.6573 4.40202 11.5333L11.6074 10.956L14.3834 4.28Z" fill="#FED323" />
-    </svg>
-  );
   return (
     <div className={styles.container}>
       <div className={styles.text}>
         <div className={styles.starContainer}>
-          {starSvg}
-          {starSvg}
-          {starSvg}
-          {starSvg}
-          {starSvg}
+          <StarSvg />
+          <StarSvg />
+          <StarSvg />
+          <StarSvg />
+          <StarSvg />
         </div>
         <h2>Based on 10,000+ reviews.</h2>
         <p>


### PR DESCRIPTION
This refactoring effort suggests moving the `starSvg` constant into a separate component in order to improve readability and maintainability. Also, the import statement for `EmployeeCardStack` seems to be incorrect. It's been refactored to import from the right path.