### PR TITLE
Refactored 'AdminPrivateRoute' Component for Enhanced Readability and Maintainability

### DIFF
--- a/src/client/components/PrivateRoutes/AdminPrivateRoute.tsx
+++ b/src/client/components/PrivateRoutes/AdminPrivateRoute.tsx
@@ -7,7 +7,13 @@ interface IProps {
 }
 
 const AdminPrivateRoute = ({ children }: IProps): React.JSX.Element => {
-  const { role, load } = useContext(AuthContext) ?? { role: '', load: false };
+  const authContext = useContext(AuthContext);
+  let role = '';
+  let load = false;
+    
+  if(authContext !== undefined) {
+    ({ role, load } = authContext);
+  }
 
   if (!load) {
     return <div>LOADING...</div>;


### PR DESCRIPTION
In the 'AdminPrivateRoute' component, rather than destructuring 'role' and 'load' directly from AuthContext, this change first checks if AuthContext is defined. This better handles the case when AuthContext is undefined by making the intention clear, thus improving readability. It also removes the duplicated default object { role: '', load: false } which enhanced maintainability.