### PR TITLE
Removed Redundant Error Checking in 'handleSubmit' Function

### DIFF
--- a/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
+++ b/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
@@ -60,9 +60,6 @@ const ForgotPassword: FunctionComponent = () => {
         throw new Error('success variable not type boolean: ForgotPassword.tsx');
       }
 
-      if (typeof result.success !== 'boolean') {
-        throw new Error('success variable not type boolean: ForgotPassword.tsx');
-      }
       if (result.success) {
         setShowSuccessPopup(true);
       } else {


### PR DESCRIPTION
After fetching data from '/api/forgotPassword', the 'handleSubmit' function within the 'ForgotPassword' component currently checks twice if the 'success' property of the result object is a boolean. The redundancy can affect performance and complicate troubleshooting. This pull request removes the doubled error check to increase efficiency and simplify the code.