### PR TITLE
Rename MethodologyPage to MethodologyPageComponent for Clear Component Naming

### DIFF
--- a/src/client/pages/MethodologyPage/MethodologyPage.tsx
+++ b/src/client/pages/MethodologyPage/MethodologyPage.tsx
@@ -6,7 +6,7 @@ import MethodologyFullList from '../../components/MethodologyPage/MethodologyFul
 import MethodologyBenefits from '../../components/MethodologyPage/MethodologyBenefits/MethodologyBenefits';
 import MethodologyNeedHelp from '../../components/MethodologyPage/MethodologyNeedHelp/MethodologyNeedHelp';
 
-const MethodologyPage: FunctionComponent = () => (
+const MethodologyPageComponent: FunctionComponent = () => (
   <div>
     <Helmet>
       <meta charSet="utf-8" />
@@ -24,4 +24,4 @@ const MethodologyPage: FunctionComponent = () => (
   </div>
 );
 
-export default MethodologyPage;
+export default MethodologyPageComponent;


### PR DESCRIPTION
The TypeScript file for the Methodology page contains a React functional component named MethodologyPage, which can be easily confused with a page object or a data type. Renaming the component to MethodologyPageComponent makes it clear that it represents a React component. This change will help improve code readability and maintainability.