### PR TITLE
Refactor 'isIdArray' and 'isUsersArray' to Use a More Reliable Array Element Check

### DIFF
--- a/src/common/utilities/types.ts
+++ b/src/common/utilities/types.ts
@@ -23,9 +23,7 @@ export const isTimeObjectWithProjectArray
 
 export const isIdArray = (value: unknown): value is IdObject[] => (
   Array.isArray(value)
-  && value[0] !== null
-  && value[0] !== undefined
-  && 'id' in value[0]
+  && value.every((item) => item !== null && item !== undefined && 'id' in item)
 );
 
 const isEmployeeTimesheet
@@ -48,12 +46,14 @@ export const isEmployeeTimesheetArray
 export const isUsersArray
  = (value: unknown): value is UserIdNameEmailRole[] => (
    Array.isArray(value)
-   && value[0] !== null
-   && value[0] !== undefined
-    && 'id' in value[0]
-    && 'username' in value[0]
-    && 'email' in value[0]
-    && 'role' in value[0]
+   && value.every((item) => 
+        item !== null &&
+        item !== undefined &&
+        'id' in item &&
+        'username' in item &&
+        'email' in item &&
+        'role' in item
+      )
  );
 
 const isClientProject


### PR DESCRIPTION

The original implementation of 'isIdArray' and 'isUsersArray' functions assumed that checking only the first element of the potential array will suffice to prove the array's type integrity. This approach can lead to false positives because only the first element is validated, and subsequent elements might not match the expected type.

To improve reliability, both functions should iterate over all elements to confirm that every item in the array conforms to the expected structure.

This refactor enhances code robustness by ensuring that arrays are inspected more thoroughly, reducing the possibility of type errors during runtime.
