### PR TITLE
Renamed 'AccordianPanel' to 'AccordionPanel' for Correct Spelling

### DIFF
--- a/src/client/components/AccordianPanel/AccordianPanel.tsx
+++ b/src/client/components/AccordianPanel/AccordianPanel.tsx
@@ -1,30 +1,30 @@
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useState } from 'react';
-import styles from './AccordianPanel.scss';
+import styles from './AccordionPanel.scss';
 
-type AccordianPanelProps = {
+type AccordionPanelProps = {
   question: string;
   answer: string;
 };
 
-const AccordianPanel: FunctionComponent<AccordianPanelProps>
+const AccordionPanel: FunctionComponent<AccordionPanelProps>
  = ({ question, answer }) => {
    const [isOpen, setIsOpen] = useState(false);
    const openClosePanel = useCallback(() => {
      setIsOpen(!isOpen);
    }, [isOpen]);
    return (
-     <div className={styles.accordianPanelContainer}>
-       <div className={styles.accordianQuestion} onClick={openClosePanel}>
+     <div className={styles.accordionPanelContainer}>
+       <div className={styles.accordionQuestion} onClick={openClosePanel}>
          <h3>{question}</h3>
          <div className={styles.panelArrow}>
            {'>'}
          </div>
        </div>
-       <div className={styles.accordianDivider} />
-       {isOpen && <p className={styles.accordianAnswer}>{answer}</p>}
+       <div className={styles.accordionDivider} />
+       {isOpen && <p className={styles.accordionAnswer}>{answer}</p>}
      </div>
    );
  };
 
-export default AccordianPanel;
+export default AccordionPanel;


### PR DESCRIPTION

The component and file names had a typo in the word "Accordion." This pull request corrects the spelling error, which improves codebase readability and clarity. Renaming 'AccordianPanel' to 'AccordionPanel' avoids confusion for future developers and maintains consistency with the standard spelling of "accordion."

While this change may not affect the component's functionality, the value in standardizing the spelling for better maintainability and understanding is significant, especially considering that the misspelling could lead to search and import issues within a larger codebase.
