### PR TITLE
Refactor createTimesheet to Handle All Errors Gracefully

### DIFF
--- a/src/server/common/utilities/createTimesheet.ts
+++ b/src/server/common/utilities/createTimesheet.ts
@@ -1,17 +1,20 @@
 import { checkTimesheet, insertTimesheet } from '../../database';
 import logger from '../../logger';
 
-export const createTimesheet = async(
+export const createTimesheet = async (
   userId: number, weekStart: number,
   weekEnd: number
 ): Promise<void> => {
-  const recordExists = await checkTimesheet(userId, weekStart, weekEnd);
-  if (!recordExists) {
-    await insertTimesheet(userId, weekStart, weekEnd).catch((err) => {
-      if (err instanceof Error) {
-        logger.error(err.message);
-      }
-    });
+  try {
+    const recordExists = await checkTimesheet(userId, weekStart, weekEnd);
+    if (!recordExists) {
+      await insertTimesheet(userId, weekStart, weekEnd);
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error(`Error in createTimesheet for User ID ${userId}: ${err.message}`);
+    } else {
+      logger.error(`Unknown error in createTimesheet for User ID ${userId}`);
+    }
   }
 };
-


### PR DESCRIPTION

The 'createTimesheet' function previously caught errors specifically when 'insertTimesheet' failed. The refactoring extends error handling to cover both 'checkTimesheet' and 'insertTimesheet', with a unified approach for logging. Any error during the timesheet creation process is now caught and logged, ensuring that all potential issues are properly recorded without crashing the application.
