### PR TITLE
Refactor JobOpeningCard to Destructure ButtonSize Enum Directly

### DIFF
--- a/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
+++ b/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
@@ -1,6 +1,7 @@
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import Button, { ButtonSize } from '../../../Button/Button';
+import Button from '../../../Button/Button';
+import { ButtonSize } from '../../../Button/Button';
 import useIsMobileWidth from '../../../../hooks/useIsMobileWidth';
 import styles from './JobOpeningCard.scss';
 
@@ -11,6 +12,8 @@ type JobOpeningCardProps = {
   url: string;
 };
 
+const { Small, Medium } = ButtonSize;
+
 const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
   position,
   type,
@@ -18,7 +21,7 @@ const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
   url,
 }) => {
   const isMobileWidth = useIsMobileWidth();
-  const buttonSize = isMobileWidth ? ButtonSize.Small : ButtonSize.Medium;
+  const buttonSize = isMobileWidth ? Small : Medium;
   return (
     <div className={styles.container}>
       <div className={styles.text}>


### PR DESCRIPTION

The intention of this change is to improve the readability of the JobOpeningCard component by directly destructuring the ButtonSize enum. This offers a clearer indication of which specific sizes we expect our button to possibly utilize, and adheres to best practices of avoiding excessive dot notation when not necessary, which can make the code cleaner and slightly more performant.

This is a minor change and should not affect the functionality of the component. No new tests are necessary, but existing tests should be run to ensure no unforeseen issues occur.
