### PR TITLE
Refactor JobOpeningCard to Use useMemo for ButtonSize Calculation

### DIFF
--- a/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
+++ b/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import Button, { ButtonSize } from '../../../Button/Button';
 import useIsMobileWidth from '../../../../hooks/useIsMobileWidth';
 import styles from './JobOpeningCard.scss';
@@ -18,7 +18,11 @@ const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
   url,
 }) => {
   const isMobileWidth = useIsMobileWidth();
-  const buttonSize = isMobileWidth ? ButtonSize.Small : ButtonSize.Medium;
+  const buttonSize = useMemo(
+    () => (isMobileWidth ? ButtonSize.Small : ButtonSize.Medium),
+    [isMobileWidth]
+  );
+
   return (
     <div className={styles.container}>
       <div className={styles.text}>


### PR DESCRIPTION
Optimize the JobOpeningCard component to avoid recalculating the buttonSize on every render when the isMobileWidth value has not changed. By using useMemo, we prevent unnecessary recalculations and potentially improve performance when rendering multiple JobOpeningCards.