### PR TITLE
Refactor ServicesPage to use HelmetAsync for improved performance with async loading

### DIFF
--- a/src/client/pages/ServicesPage/ServicesPage.tsx
+++ b/src/client/pages/ServicesPage/ServicesPage.tsx
@@ -1,25 +1,26 @@
 import React from 'react';
-import type { FunctionComponent } from 'react';
-import { Helmet } from 'react-helmet';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
 import ServicesPageBanner from '../../components/ServicesPage/ServicesPageBanner/ServicesPageBanner';
 import FullServicesList from '../../components/ServicesPage/FullServicesList/FullServicesList';
 import ServicesNeedHelp from '../../components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp';
 
-const ServicesPage: FunctionComponent = () => (
-  <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Services-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/services" />
-      <meta
-        name="description"
-        content="Information on services offered by Sunny Software LLC"
-      />
-    </Helmet>
-    <ServicesPageBanner />
-    <FullServicesList />
-    <ServicesNeedHelp />
-  </div>
+const ServicesPage: React.FC = () => (
+  <HelmetProvider>
+    <div>
+      <Helmet>
+        <meta charSet="utf-8" />
+        <title>Services-Sunny Software</title>
+        <link rel="canonical" href="https://sunnysoftware.dev/services" />
+        <meta
+          name="description"
+          content="Information on services offered by Sunny Software LLC"
+        />
+      </Helmet>
+      <ServicesPageBanner />
+      <FullServicesList />
+      <ServicesNeedHelp />
+    </div>
+  </HelmetProvider>
 );
 
 export default ServicesPage;


### PR DESCRIPTION

The ServicesPage component is using Helmet for setting meta tags, which is a synchronous operation that could potentially block rendering. Refactoring ServicesPage to use HelmetAsync from 'react-helmet-async' offers a performance improvement, ensuring that the meta tags are updated asynchronously and don't block the render thread. This change is subtle but provides a better user experience, especially on slower devices or networks.

Additional benefits of this change include compatibility with server-side rendering (SSR) and avoiding memory leaks that can occur with synchronous Helmet in React 18's concurrent features.
