### PR TITLE
Refactor ServicesPageBanner to Improve SVG Background Rendering

### DIFF
--- a/src/client/components/ServicesPage/ServicesPageBanner/ServicesPageBanner.tsx
+++ b/src/client/components/ServicesPage/ServicesPageBanner/ServicesPageBanner.tsx
@@ -5,25 +5,26 @@ import styles from './ServicesPageBanner.scss';
 import papersImage from './PapersImage.png';
 import textAndEmojisImage from './TextAndEmojis.png';
 
+const BackgroundSvg: FunctionComponent = () => (
+  <svg width="979" height="261" viewBox="0 0 979 261" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g opacity="0.6" filter="url(#filter0_f_69_6553)">
+      <path d="M238.458 758.661C69.8249 604.081 45.3189 356.37 183.723 205.384C322.126 54.3983 571.029 57.3123 739.662 211.893C908.296 366.473 932.802 614.184 794.398 765.17C601.962 438.939 407.092 913.242 238.458 758.661Z" fill="url(#paint0_linear_69_6553)" />
+    </g>
+    <defs>
+      <filter id="filter0_f_69_6553" x="0.0393066" y="0.0238037" width="978.042" height="884.58" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="47" result="effect1_foregroundBlur_69_6553" />
+      </filter>
+      <linearGradient id="paint0_linear_69_6553" x1="1045" y1="491.786" x2="-57.3113" y2="600.837" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#F3AA1F" />
+        <stop offset="1" stopColor="#FED323" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+
 const ServicesPageBanner: FunctionComponent = () => {
-  const backgroundSvg = (
-    <svg width="979" height="261" viewBox="0 0 979 261" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <g opacity="0.6" filter="url(#filter0_f_69_6553)">
-        <path d="M238.458 758.661C69.8249 604.081 45.3189 356.37 183.723 205.384C322.126 54.3983 571.029 57.3123 739.662 211.893C908.296 366.473 932.802 614.184 794.398 765.17C601.962 438.939 407.092 913.242 238.458 758.661Z" fill="url(#paint0_linear_69_6553)" />
-      </g>
-      <defs>
-        <filter id="filter0_f_69_6553" x="0.0393066" y="0.0238037" width="978.042" height="884.58" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feGaussianBlur stdDeviation="47" result="effect1_foregroundBlur_69_6553" />
-        </filter>
-        <linearGradient id="paint0_linear_69_6553" x1="1045" y1="491.786" x2="-57.3113" y2="600.837" gradientUnits="userSpaceOnUse">
-          <stop stopColor="#F3AA1F" />
-          <stop offset="1" stopColor="#FED323" />
-        </linearGradient>
-      </defs>
-    </svg>
-  );
   return (
     <div className={styles.container}>
       <img className={styles.leftImage} src={papersImage} alt="picture of papers" />
@@ -39,7 +40,7 @@ const ServicesPageBanner: FunctionComponent = () => {
         </Button>
       </div>
       <img className={styles.rightImage} src={textAndEmojisImage} alt="emojies graphic" />
-      {backgroundSvg}
+      <BackgroundSvg />
     </div>
   );
 };


### PR DESCRIPTION

The current implementation of ServicesPageBanner component directly includes a large SVG graphic within the component's function body. This could potentially make the component less readable and the SVG difficult to maintain. To address this, I've extracted the SVG into a separate React component, which improves the overall structure, making the code more maintainable and the ServicesPageBanner component cleaner and more focused on its primary function.

This extraction not only increases readability but also sets a good precedent for managing future SVG assets. If additional SVG graphics are needed, they can be added as separate components without cluttering the primary view components.
