### PR TITLE
Rename 'Accordian' to 'Accordion', fix typo across the component

### DIFF
--- a/src/client/components/AccordianPanel/AccordianPanel.tsx
+++ b/src/client/components/AccordianPanel/AccordianPanel.tsx
@@ -1,30 +1,30 @@
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useState } from 'react';
-import styles from './AccordianPanel.scss';
+import styles from './AccordionPanel.scss';
 
-type AccordianPanelProps = {
+type AccordionPanelProps = {
   question: string;
   answer: string;
 };
 
-const AccordianPanel: FunctionComponent<AccordianPanelProps>
+const AccordionPanel: FunctionComponent<AccordionPanelProps>
  = ({ question, answer }) => {
    const [isOpen, setIsOpen] = useState(false);
    const openClosePanel = useCallback(() => {
      setIsOpen(!isOpen);
    }, [isOpen]);
    return (
-     <div className={styles.accordianPanelContainer}>
-       <div className={styles.accordianQuestion} onClick={openClosePanel}>
+     <div className={styles.accordionPanelContainer}>
+       <div className={styles.accordionQuestion} onClick={openClosePanel}>
          <h3>{question}</h3>
          <div className={styles.panelArrow}>
            {'>'}
          </div>
        </div>
-       <div className={styles.accordianDivider} />
-       {isOpen && <p className={styles.accordianAnswer}>{answer}</p>}
+       <div className={styles.accordionDivider} />
+       {isOpen && <p className={styles.accordionAnswer}>{answer}</p>}
      </div>
    );
  };
 
-export default AccordianPanel;
+export default AccordionPanel;


### PR DESCRIPTION
The component and associated SCSS module refer to an 'AccordianPanel' when the correct spelling is 'AccordionPanel'. This change fixes all instances of the misspelling for consistency and accuracy across the component and the related styles.