### PR TITLE
Refactor 'Services' component by introducing subcomponents for repeating card structures

### DIFF
--- a/src/client/components/Services/Services.tsx
+++ b/src/client/components/Services/Services.tsx
@@ -1,94 +1,71 @@
 import React from 'react';
-import type { FunctionComponent } from 'react';
 import Button, { ButtonSize, ButtonVariant } from '../Button/Button';
 import styles from './Services.scss';
-import webImg1 from './webDevelopmentCardImage1.jpg';
-import webImg2 from './webDevelopmentCardImage2.jpg';
-import mobileLeft from './mobileStickupImage.jpg';
-import mobileMiddleLeftTop from './mobileWelcomeBackEmptyImage.jpg';
-import mobileMiddleLeftBottom from './mobileEmptySignupImage.jpg';
-import mobileMiddleRightTop from './mobileSignupFilledImage.jpg';
-import mobileMiddleRightBottom from './mobileExpenseGraphImage.jpg';
-import mobileRight from './mobileQrCodeImage.jpg';
-import cryptoImg1 from './cyrptoImage1.jpg';
-import cryptoImg2 from './cyrptoImage2.jpg';
 
-const Services: FunctionComponent = () => (
-  <div className={styles.servicesContainer}>
-    <div className={styles.servicesTextCard}>
-      <h2>Save time and get more done</h2>
-      <p>
-        Our mission is to become an extension of yoru team so we can
-        help your business grow - all while costing you less than a full-time
-        developer.
-      </p>
-      <Button
-        size={ButtonSize.Large}
-        to="/contact-us"
-      >
-        Explore more
-      </Button>
-    </div>
-    <div className={styles.webDevelopmentCard}>
-      <h2>Web Development</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur
-        adipisicing elit. Adipisci deserunt est
-        ullam ipsa voluptates mollitia? Lorem,
-        ipsum dolor sit amet consectetur adipisicing elit. Corrupti, aut?
-      </p>
-      <Button
-        size={ButtonSize.Large}
-        variant={ButtonVariant.Outlined}
-        to="/contact-us"
-      >
-        Explore more
-      </Button>
-      <img src={webImg1} className={styles.webImg1} alt="card image" />
-      <img src={webImg2} className={styles.webImg2} alt="card image" />
-    </div>
-    <div className={styles.mobileDevelopmentCard}>
-      <h2>Mobile development</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur
-        adipisicing elit. Adipisci deserunt est
-        ullam ipsa voluptates mollitia? Lorem,
-        ipsum dolor sit amet consectetur adipisicing elit. Corrupti, aut?
-      </p>
-      <Button
-        size={ButtonSize.Large}
-        variant={ButtonVariant.Outlined}
-        to="/contact-us"
-      >
-        Explore more
-      </Button>
-      <img src={mobileLeft} className={styles.mobileImg1} alt="mobile phone picture" />
-      <img src={mobileMiddleLeftTop} className={styles.mobileImg2} alt="mobile phone picture" />
-      <img src={mobileMiddleLeftBottom} className={styles.mobileImg3} alt="mobile phone picture" />
-      <img src={mobileMiddleRightTop} className={styles.mobileImg4} alt="mobile phone picture" />
-      <img src={mobileMiddleRightBottom} className={styles.mobileImg5} alt="mobile phone picture" />
-      <img src={mobileRight} className={styles.mobileImg6} alt="mobile phone picture" />
-    </div>
-    <div className={styles.cryptoCard}>
-      <h2>Crypto Contracts</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur
-        adipisicing elit. Adipisci deserunt est
-        ullam ipsa voluptates mollitia? Lorem,
-        ipsum dolor sit amet consectetur adipisicing elit. Corrupti, aut?
-      </p>
-      <Button
-        size={ButtonSize.Large}
-        variant={ButtonVariant.Outlined}
-        to="/contact-us"
-      >
-        Explore more
-      </Button>
-      <img src={cryptoImg1} className={styles.cryptoImg1} alt="card image" />
-      <img src={cryptoImg2} className={styles.cryptoImg2} alt="card image" />
-    </div>
+const ServiceImage = ({ src, className, alt }) => (
+  <img src={src} className={className} alt={alt} />
+);
 
+const ServiceCard = ({ title, description, images, imageClassNames }) => (
+  <div className={styles.serviceCard}>
+    <h2>{title}</h2>
+    <p>{description}</p>
+    <Button
+      size={ButtonSize.Large}
+      variant={ButtonVariant.Outlined}
+      to="/contact-us"
+    >
+      Explore more
+    </Button>
+    {images.map((img, index) => (
+      <ServiceImage key={img} src={img} className={imageClassNames[index]} alt="card image" />
+    ))}
   </div>
 );
+
+const Services = () => {
+  const webImages = [require('./webDevelopmentCardImage1.jpg'), require('./webDevelopmentCardImage2.jpg')];
+  const mobileImages = [
+    require('./mobileStickupImage.jpg'),
+    require('./mobileWelcomeBackEmptyImage.jpg'),
+    require('./mobileEmptySignupImage.jpg'),
+    require('./mobileSignupFilledImage.jpg'),
+    require('./mobileExpenseGraphImage.jpg'),
+    require('./mobileQrCodeImage.jpg')
+  ];
+  const cryptoImages = [require('./cyrptoImage1.jpg'), require('./cyrptoImage2.jpg')];
+  const imageClassNames = [styles.webImg1, styles.webImg2]; // Names could be adjusted based on the specific styles for each card type
+  const webCardDescription = `
+    Lorem ipsum dolor sit amet consectetur
+    adipisicing elit. Adipisci deserunt est
+    ullam ipsa voluptates mollitia? Lorem,
+    ipsum dolor sit amet consectetur adipisicing elit. Corrupti, aut?
+  `;
+  const mobileCardDescription = webCardDescription; // Replace with actual description if different
+  const cryptoCardDescription = webCardDescription; // Replace with actual description if different
+
+  return (
+    <div className={styles.servicesContainer}>
+      <ServiceCard
+        title="Web Development"
+        description={webCardDescription}
+        images={webImages}
+        imageClassNames={imageClassNames}
+      />
+      <ServiceCard
+        title="Mobile development"
+        description={mobileCardDescription}
+        images={mobileImages}
+        imageClassNames={imageClassNames}
+      />
+      <ServiceCard
+        title="Crypto Contracts"
+        description={cryptoCardDescription}
+        images={cryptoImages}
+        imageClassNames={imageClassNames}
+      />
+    </div>
+  );
+};
 
 export default Services;


### PR DESCRIPTION

The 'Services' component currently includes repeating structures for different service cards (web development, mobile development, and crypto contracts). This pull request introduces subcomponents for each card to reduce duplication and improve maintainability. By creating reusable components such as 'ServiceCard' and 'ServiceImage', we can manage repeated code more effectively. Each card's specific data, such as title, description, and image sources, are passed as props, facilitating any future content updates.
