### PR TITLE
Refactor 'StatisticsBar' to Use a Map for Statistic Items

### DIFF
--- a/src/client/components/AboutUsPage/StatisticsBar/StatisticsBar.tsx
+++ b/src/client/components/AboutUsPage/StatisticsBar/StatisticsBar.tsx
@@ -2,24 +2,26 @@ import type { FunctionComponent } from 'react';
 import React from 'react';
 import styles from './StatisticsBar.scss';
 
+type StatisticItem = {
+  value: string;
+  description: string;
+};
+
+const statisticItems: StatisticItem[] = [
+  { value: '15+', description: 'Years of experience' },
+  { value: '1K+', description: 'Happy Customers' },
+  { value: '80+', description: 'Completed projects' },
+  { value: '95%', description: 'Positive reviews' },
+];
+
 const StatisticsBar: FunctionComponent = () => (
   <div className={styles.barContainer}>
-    <div className={styles.statistic}>
-      <h2>15+</h2>
-      <p>Years of experience</p>
-    </div>
-    <div className={styles.statistic}>
-      <h2>1K+</h2>
-      <p>Happy Customers</p>
-    </div>
-    <div className={styles.statistic}>
-      <h2>80+</h2>
-      <p>Completed projects</p>
-    </div>
-    <div className={styles.statistic}>
-      <h2>95%</h2>
-      <p>Positive reviews</p>
-    </div>
+    {statisticItems.map((item, index) => (
+      <div key={index} className={styles.statistic}>
+        <h2>{item.value}</h2>
+        <p>{item.description}</p>
+      </div>
+    ))}
   </div>
 );
 


### PR DESCRIPTION

The existing 'StatisticsBar' component statically renders four blocks of statistics, which hinders reusability and scalability. By refactoring the component to map over a data array of statistics, we make additions or modifications to the statistics effortlessly in the future. This also improves the readability of the code, as it reduces repetition and clearly separates data from presentation logic.
