### PR TITLE
Improve 'useChangeHandler' Reliability by Removing Redundant Type Check

### DIFF
--- a/src/client/hooks/useChangeHandler.ts
+++ b/src/client/hooks/useChangeHandler.ts
@@ -8,12 +8,7 @@ type ChangeHandler = (e: ChangeEvent<HTMLSelectElement>) => void;
 const useChangeHandler = (setterCallback: SetterCallback): ChangeHandler => {
   const changeHandler: ChangeHandler = (e) => {
     e.preventDefault();
-    const { target } = e;
-    if (target instanceof HTMLSelectElement) {
-      setterCallback(e.target.value);
-    } else {
-      logger.info('type error in TimeDropdown: handleValueChange');
-    }
+    setterCallback(e.target.value);
   };
   return useCallback(changeHandler, [setterCallback]);
 };


### PR DESCRIPTION

The existing 'useChangeHandler' function explicitly checks if 'e.target' is an instance of 'HTMLSelectElement', which is redundant given the TypeScript type definition for 'ChangeHandler'. The type definition ensures that 'e.target' will be 'HTMLSelectElement', thereby making the type check unnecessary. By removing the check, we simplify the function and eliminate an unreachable code path to increase reliability.

This change should have no impact on the runtime functionality, but it improves maintainability and confidence in TypeScript's static type checking.
