### PR TITLE
Refactor ServicesPage to Utilize Helmet for Improved SEO

### DIFF
--- a/src/client/pages/ServicesPage/ServicesPage.tsx
+++ b/src/client/pages/ServicesPage/ServicesPage.tsx
@@ -5,17 +5,28 @@ import ServicesPageBanner from '../../components/ServicesPage/ServicesPageBanner
 import FullServicesList from '../../components/ServicesPage/FullServicesList/FullServicesList';
 import ServicesNeedHelp from '../../components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp';
 
+interface SEOHelmetProps {
+  title: string;
+  description: string;
+  url: string;
+}
+
+const SEOHelmet: FunctionComponent<SEOHelmetProps> = ({ title, description, url }) => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>{title}</title>
+    <link rel="canonical" href={url} />
+    <meta name="description" content={description} />
+  </Helmet>
+);
+
 const ServicesPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Services-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/services" />
-      <meta
-        name="description"
-        content="Information on services offered by Sunny Software LLC"
-      />
-    </Helmet>
+    <SEOHelmet
+      title="Services - Sunny Software"
+      description="Information on services offered by Sunny Software LLC"
+      url="https://sunnysoftware.dev/services"
+    />
     <ServicesPageBanner />
     <FullServicesList />
     <ServicesNeedHelp />


### PR DESCRIPTION

By leveraging the Helmet component's reusable nature, we can improve the SEO configuration of the ServicesPage without redundancy. This pull request introduces a new component, SEOHelmet, which encapsulates SEO-specific properties such as the charset, title, canonical link, and meta description. By refactoring these properties into a dedicated component, we adhere to the DRY (Don't Repeat Yourself) principle, making future SEO adjustments more centralized and maintainable. Moreover, this enables other pages to utilize the SEOHelmet component effortlessly, ensuring consistency across different pages with minimal code duplication.
