### PR TITLE
Update 'ResourcesPage' title to be specific to Resources

### DIFF
--- a/src/client/pages/ResourcesPage/ResourcesPage.tsx
+++ b/src/client/pages/ResourcesPage/ResourcesPage.tsx
@@ -8,7 +8,7 @@ const ResourcesPage: FunctionComponent = () => (
   <div>
     <Helmet>
       <meta charSet="utf-8" />
-      <title>Portfolio-Sunny Software</title>
+      <title>Resources - Sunny Software</title>
       <link rel="canonical" href="https://sunnysoftware.dev/resources" />
       <meta
         name="description"


### PR DESCRIPTION

The change ensures that the HTML title element is specific to the Resources page of the portfolio, improving search engine optimization and the user experience. It differentiates this page from others within the portfolio, such as a potential Home or Contact page. 

The previous title "Portfolio-Sunny Software" was too generic and could apply to any portfolio page. The updated title "Resources - Sunny Software" clearly states that the user is on the Resources section of Sunny Software's portfolio.
