### PR TITLE
Provide Default CORS Origins for `initializeServer` Function

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,16 +8,17 @@ import html from './html';
 
 export const initializeServer = async(): Promise<void> => (
   new Promise((resolve) => {
-    const PORT = 3000;
+    const PORT = process.env.PORT || 3000;
+    const ENV_ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS?.split(',');
 
     const app = express();
 
     const clientDirectory = path.join(__dirname, './client');
-
     app.use(express.static(clientDirectory));
 
-    // CORS options
-    const allowedOrigins = ['localhost:3000'];
+    const defaultAllowedOrigins = ['http://localhost:3000'];
+    const allowedOrigins = ENV_ALLOWED_ORIGINS?.length ? ENV_ALLOWED_ORIGINS : defaultAllowedOrigins;
+
     const options: cors.CorsOptions = {
       origin: allowedOrigins,
     };


### PR DESCRIPTION

To enhance the stability of the `initializeServer` function, it is beneficial to account for the possibility that environmental variables in deployment might dictate a differing list of allowed origins for CORS. This update safely defaults to an existing local origin if the environmental variable is not present or is empty. Furthermore, this practice aligns the code with twelve-factor app methodology for configuration management by externalizing configuration to the environment.

The chosen modification provides a straightforward and impactful enhancement without unnecessary complexity.
