### PR TITLE
Optimize 'LandingPage' Component Rendering with React.Fragment

### DIFF
--- a/src/client/pages/LandingPage/LandingPage.tsx
+++ b/src/client/pages/LandingPage/LandingPage.tsx
@@ -12,7 +12,7 @@ import FrequentlyAskedQuestions from '../../components/FrequentlyAskedQuestions/
 import ResourcesPanel from '../../components/ResourcesPanel/ResourcesPanel';
 
 const LandingPage: FunctionComponent = () => (
-  <div>
+  <>
     <Helmet>
       <meta charSet="utf-8" />
       <title>Sunny Software</title>
@@ -28,7 +28,7 @@ const LandingPage: FunctionComponent = () => (
     <FrequentlyAskedQuestions />
     <ResourcesPanel />
     <CallToAction />
-  </div>
+  </>
 );
 
 export default LandingPage;


### PR DESCRIPTION
The 'LandingPage' component currently uses a `div` as a wrapper for its children, which adds an unnecessary DOM element. By using React.Fragment (`<>` syntax), we can avoid adding extra nodes to the DOM, leading to a more efficient rendering process and cleaner output in the browser's DOM tree. This is a small but valuable optimization for the component's output structure without affecting its functionality or visual representation.