### PR TITLE
Rename 'handleEdit' to 'toggleEditState' to Clearly Reflect Action

### DIFF
--- a/src/client/components/IndividualProjects/IndividualProjects.tsx
+++ b/src/client/components/IndividualProjects/IndividualProjects.tsx
@@ -11,7 +11,7 @@ const IndividualProject: FunctionComponent<ClientProject> = (props) => {
 
   const [editing, setEditing] = useState(false);
 
-  const handleEdit = useCallback(() => {
+  const toggleEditState = useCallback(() => {
     setEditing(!editing);
   }, [editing]);
 
@@ -30,7 +30,7 @@ const IndividualProject: FunctionComponent<ClientProject> = (props) => {
           {active ? 'true' : 'false'}
         </h4>
       </div>
-      <button type="button" onClick={handleEdit}>More...</button>
+      <button type="button" onClick={toggleEditState}>More...</button>
       {editing && (
         <EditProject
           id={id}


### PR DESCRIPTION

The current function name 'handleEdit' in the IndividualProject component is somewhat ambiguous and does not explicitly convey what the function does. This refactor renames the function to 'toggleEditState' to make it immediately clear that the function is meant to toggle the boolean state of 'editing'. Clear function names are important for both readability and maintainability of the codebase, and this change makes it easier to understand the component's logic at a glance.

Renaming a function is a simple but effective means of improving code clarity and the developer experience, as it reduces the cognitive load required to understand what the function is responsible for. This type of naming convention can also help establish best practices within the team for consistently clear and descriptive naming.
