### PR TITLE
Refactor duplicate boolean type check for 'result.success' in 'handleSubmit' of ForgotPassword component

### DIFF
--- a/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
+++ b/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
@@ -57,10 +57,6 @@ const ForgotPassword: FunctionComponent = () => {
       if (typeof result.success !== 'boolean') {
         throw new Error('success variable not type boolean: ForgotPassword.tsx');
       }
-
-      if (typeof result.success !== 'boolean') {
-        throw new Error('success variable not type boolean: ForgotPassword.tsx');
-      }
       if (result.success) {
         setShowSuccessPopup(true);
       } else {
@@ -85,14 +81,14 @@ const ForgotPassword: FunctionComponent = () => {
           message="If you have an account we have sent a reset password link"
           onClick={showSuccessPopupFunction}
         />
-      ) }
+      )}
       {showErrorPopup && (
         <PopupMessage
           type={PopupType.Failure}
           message="Something went wrong, please reach out to us on the contact page"
           onClick={showErrorPopupFunction}
         />
-      ) }
+      )}
       <form
         className={styles.forgotPassword}
         onClick={handleSubmit}


### PR DESCRIPTION
The function 'handleSubmit' in the 'ForgotPassword' component has a redundant check to determine whether the variable 'result.success' is a boolean. This pull request removes the duplicate check to simplify and enhance the readability and performance of the code.