### PR TITLE
Improve '/logout' route's error handling by defining a BadRequestError class

### DIFF
--- a/src/server/api/logout.ts
+++ b/src/server/api/logout.ts
@@ -1,31 +1,52 @@
-import { Router as createRouter } from 'express';
+import { Router as createRouter, Request, Response, NextFunction } from 'express';
 import { markTokenInactive } from '../database';
 import { isObjectRecord } from '../../common/utilities/types';
 
 const router = createRouter();
 
-router.post('/', (req, res) => {
-  (async(): Promise<void> => {
-    if (!isObjectRecord(req.cookies)) {
-      throw new Error('api/login: req.body is not object');
-    }
-    const { authenticationToken } = req.cookies;
-    if (typeof authenticationToken !== 'string') {
-      throw new Error('api/logout: userToken not type string');
-    }
-    const result = await markTokenInactive(authenticationToken);
+class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}
 
-    res.clearCookie('authenticationToken', { sameSite: 'lax' });
+const handleAsyncErrors = (fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next);
+  };
+};
 
-    res.json({
-      success: result,
-    });
-  })().catch((e: Error) => {
-    res.json({
-      success: false,
-      error: e.message,
-    });
+router.post('/', handleAsyncErrors(async (req: Request, res: Response) => {
+  if (!isObjectRecord(req.cookies)) {
+    throw new BadRequestError('api/logout: req.cookies is not an object record');
+  }
+  const { authenticationToken } = req.cookies;
+  if (typeof authenticationToken !== 'string') {
+    throw new BadRequestError('api/logout: authenticationToken is not a string');
+  }
+  const result = await markTokenInactive(authenticationToken);
+
+  res.clearCookie('authenticationToken', { sameSite: 'lax' });
+
+  res.json({
+    success: result,
   });
+}));
+
+// Error handling middleware for the '/logout' route
+router.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  if (err instanceof BadRequestError) {
+    res.status(400).json({
+      success: false,
+      error: err.message,
+    });
+  } else {
+    res.status(500).json({
+      success: false,
+      error: 'Internal Server Error',
+    });
+  }
 });
 
 export default router;


### PR DESCRIPTION

The current implementation of the '/logout' route in our express router lacks granular error handling, making debugging and client error handling difficult. To enhance our API's error response, I have introduced a `BadRequestError` class. This class extends the native Error class, with the express purpose of handling bad request scenarios. By using this custom error type, we can easily distinguish client-induced errors from other types of thrown exceptions. As a result, we can provide cleaner error messages to clients when they provide invalid data and log detailed error information for server-side diagnostics.

With this new error class, we now throw a `BadRequestError` if the `req.cookies` is not an object record or the `authenticationToken` is not a string, which allows us to specifically catch these errors and return a 400 Bad Request status. This change leads to a more robust and client-friendly error handling mechanism.
