### PR TITLE
Optimized 'handleActiveChange' for Direct State Manipulation in 'EditProject' Component

### DIFF
--- a/src/client/components/EditProject/EditProject.tsx
+++ b/src/client/components/EditProject/EditProject.tsx
@@ -24,15 +24,14 @@ const EditProject: FunctionComponent<ClientProject> = (props) => {
     [setNewTitle],
   );
 
-  const handleDescriptionChange
-   = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
-     setNewDescription(e.target.value);
-     setSubmitted(false);
-   }, [setNewDescription],);
+  const handleDescriptionChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    setNewDescription(e.target.value);
+    setSubmitted(false);
+  }, [setNewDescription],);
 
   const handleActiveChange = useCallback((): void => {
-    setNewActive(!active);
-  }, [active],);
+    setNewActive(!newActive);
+  }, [newActive],);
 
   // Update Project information
   const handleSubmit = useCallback(async(e: SyntheticEvent) => {


### PR DESCRIPTION

The 'handleActiveChange' function in the 'EditProject' component previously toggled the state based on the old 'active' prop, which could lead to unexpected behavior if 'props.active' was updated independently of the local 'newActive' state. By directly referencing 'newActive' instead, we ensure that the state is toggled based on the current local state, not an outdated prop. This change enhances the accuracy and reliability of the state toggle behavior.
