### PR TITLE
Refactor redundant FAQ answer data into a single source

### DIFF
--- a/src/client/components/FAQPage/FullFAQ/FullFAQ.tsx
+++ b/src/client/components/FAQPage/FullFAQ/FullFAQ.tsx
@@ -4,54 +4,40 @@ import AccordianPanel from '../../AccordianPanel/AccordianPanel';
 import styles from './FullFAQ.scss';
 
 const FullFAQ: FunctionComponent = () => {
+  const commonAnswer = `You and your team can request design work through a shared board we will set up for you in Asana. You can request as many designs as you like.`;
+
   const faqData = [
     {
       question: 'Question 1',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 2',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 3',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 4',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 5',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 6',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 7',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
     {
       question: 'Question 8',
-      answer: `You and your team can request design work through a
-      shared board we will set up for you in Asana. You can request as
-      many designs as you like.`,
+      answer: commonAnswer,
     },
   ];
 


### PR DESCRIPTION

The FullFAQ component contains repetitive answer strings that can be refactored to improve readability and maintainability. Having a single source of truth for the frequently repeated answer string will simplify future updates or translations. I've extracted the common answer text and used it within the faqData array. This change makes it easier to maintain the FAQ data, especially if the answer needs to change in the future – we would only need to modify it in one place.
