### PR TITLE
Extract Helmet Metadata to a Separate Component for Reusability in ServicesPage

### DIFF
--- a/src/client/pages/ServicesPage/ServicesPage.tsx
+++ b/src/client/pages/ServicesPage/ServicesPage.tsx
@@ -5,17 +5,18 @@ import ServicesPageBanner from '../../components/ServicesPage/ServicesPageBanner
 import FullServicesList from '../../components/ServicesPage/FullServicesList/FullServicesList';
 import ServicesNeedHelp from '../../components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp';
 
+const ServicesPageMeta: FunctionComponent = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Services - Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/services" />
+    <meta name="description" content="Information on services offered by Sunny Software LLC" />
+  </Helmet>
+);
+
 const ServicesPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Services-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/services" />
-      <meta
-        name="description"
-        content="Information on services offered by Sunny Software LLC"
-      />
-    </Helmet>
+    <ServicesPageMeta />
     <ServicesPageBanner />
     <FullServicesList />
     <ServicesNeedHelp />


### PR DESCRIPTION

The purpose of this refactoring is to improve the modularity and reusability of the metadata management within the ServicesPage. By extracting the Helmet metadata-related elements into a separate, reusable component, we can streamline the ServicesPage component and make the metadata configuration easy to reuse across different pages.

This change enhances maintainability and promotes component reuse, which is particularly useful when similar metadata configurations are used on multiple pages throughout the application. Following best practices, this extraction aligns with the single responsibility principle, keeping the ServicesPage component focused on its primary role of rendering the services page layout.
