### PR TITLE
Rename 'OwnIdeasBottom' to 'PartnershipInquirySection' for Enhanced Semantic Clarity

### DIFF
--- a/src/client/components/CareersPage/OwnIdeasBottom/OwnIdeasBottom.tsx
+++ b/src/client/components/CareersPage/OwnIdeasBottom/OwnIdeasBottom.tsx
@@ -1,9 +1,9 @@
 import type { FunctionComponent } from 'react';
 import React from 'react';
 import Button, { ButtonSize, ButtonVariant } from '../../Button/Button';
-import styles from './OwnIdeasBottom.scss';
+import styles from './PartnershipInquirySection.scss';
 
-const OwnIdeasBottom: FunctionComponent = () => (
+const PartnershipInquirySection: FunctionComponent = () => (
   <div className={styles.container}>
     <div className={styles.text}>
       <h2>Have your own ideas for our partnership?</h2>
@@ -19,4 +19,4 @@ const OwnIdeasBottom: FunctionComponent = () => (
   </div>
 );
 
-export default OwnIdeasBottom;
+export default PartnershipInquirySection;


### PR DESCRIPTION

The 'OwnIdeasBottom' component name lacks semantic clarity and doesn't properly communicate the component's purpose, which is to invite potential partnerships. The proposed change is to rename 'OwnIdeasBottom' to 'PartnershipInquirySection' to more accurately reflect the intent and content of the component. This change helps developers understand the component's role in the application at a glance and maintain the codebase more effectively.
