### PR TITLE
Rename 'AccordianPanel' Import to 'AccordionPanel' for Correct Spelling

### DIFF
--- a/src/client/components/FrequentlyAskedQuestions/FrequentlyAskedQuestions.tsx
+++ b/src/client/components/FrequentlyAskedQuestions/FrequentlyAskedQuestions.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import AccordianPanel from '../AccordianPanel/AccordianPanel';
+import AccordionPanel from '../AccordionPanel/AccordionPanel';
 import Button, { ButtonSize } from '../Button/Button';
 import styles from './FrequentlyAskedQuestions.scss';
 
@@ -39,7 +39,7 @@ const FrequentlyAskedQuestions: FunctionComponent = () => {
       </p>
       <div className={styles.faqPanelsContainer}>
         {faqData.map(faq => (
-          <AccordianPanel
+          <AccordionPanel
             key={faq.question}
             question={faq.question} answer={faq.answer}
           />


### PR DESCRIPTION

This refactoring corrects the spelling error in the 'AccordianPanel' component import, changing it to 'AccordionPanel'. It's important to have correctly spelled code identifiers to maintain professionalism and code clarity. Though this change doesn't impact functionality, it ensures that the code base maintains a high standard of quality and readability for future developers.
