### PR TITLE
Refactor duplicated condition check in 'handleSubmit' function in ForgotPassword.tsx

### DIFF
--- a/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
+++ b/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
@@ -52,15 +52,12 @@ const ForgotPassword: FunctionComponent = () => {
       const result: unknown = await response.json();
 
       if (!isObjectRecord(result)) {
-        throw new Error('Unexpected body type: ForgotPassword.tsx');
+        throw new Error('Unexpected body type.');
       }
       if (typeof result.success !== 'boolean') {
-        throw new Error('success variable not type boolean: ForgotPassword.tsx');
+        throw new Error('Expected "success" to be a boolean.');
       }
 
-      if (typeof result.success !== 'boolean') {
-        throw new Error('success variable not type boolean: ForgotPassword.tsx');
-      }
       if (result.success) {
         setShowSuccessPopup(true);
       } else {
@@ -85,14 +82,14 @@ const ForgotPassword: FunctionComponent = () => {
           message="If you have an account we have sent a reset password link"
           onClick={showSuccessPopupFunction}
         />
-      ) }
+      )}
       {showErrorPopup && (
         <PopupMessage
           type={PopupType.Failure}
           message="Something went wrong, please reach out to us on the contact page"
           onClick={showErrorPopupFunction}
         />
-      ) }
+      )}
       <form
         className={styles.forgotPassword}
         onClick={handleSubmit}
@@ -102,7 +99,8 @@ const ForgotPassword: FunctionComponent = () => {
             Email
             <Input
               size={InputSize.Large}
-              value={email} setValue={setEmail}
+              value={email}
+              setValue={setEmail}
               onChange={handleEmailChange}
               placeholderText="example@gmail.com"
             />


### PR DESCRIPTION

The 'handleSubmit' function in 'ForgotPassword.tsx' contains a duplicated condition that checks if 'result.success' is boolean. The pull request aims to eliminate this redundant code which improves readability and maintainability.

- Remove duplicated boolean type check for 'result.success'.
- Simplify error message since the filename is evident from the logger's context.
