### PR TITLE
Optimize conditional button size assignment in 'JobOpeningCard' for readability

### DIFF
--- a/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
+++ b/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
@@ -18,7 +18,6 @@ const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
   url,
 }) => {
   const isMobileWidth = useIsMobileWidth();
-  const buttonSize = isMobileWidth ? ButtonSize.Small : ButtonSize.Medium;
   return (
     <div className={styles.container}>
       <div className={styles.text}>
@@ -27,7 +26,7 @@ const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
         <p>{description}</p>
       </div>
       <div className={styles.buttonContainer}>
-        <Button size={buttonSize} to={url}>
+        <Button size={isMobileWidth ? ButtonSize.Small : ButtonSize.Medium} to={url}>
           Apply
         </Button>
       </div>


### PR DESCRIPTION

Upon reviewing 'JobOpeningCard', I found that the conditional assignment for 'buttonSize' could be refactored for enhanced readability. Originally, 'buttonSize' was determined by a ternary operation within the component body, which works fine but can be streamlined into a single line directly in the JSX. This minuscule refactor reduces cognitive load, as the assignment logic becomes part of the JSX where it's used, making the component more declarative.

The suggested change involves using the conditional (ternary) operator directly within the Button component's 'size' prop rather than assigning it to 'buttonSize' beforehand. This not only increases code readability by keeping prop-related logic in one place but also slightly reduces the verbosity of the component by eliminating the 'buttonSize' variable.
