### PR TITLE
Rename Button Label 'See Docs' to 'Read More' for Clarity in ResourcesPanels

### DIFF
--- a/src/client/components/ResourcesPage/ResourcesPanels/ResourcesPanels.tsx
+++ b/src/client/components/ResourcesPage/ResourcesPanels/ResourcesPanels.tsx
@@ -22,7 +22,7 @@ const ResourcesPanels: FunctionComponent = () => (
         </p>
       </div>
       <div className={styles.buttonContainer}>
-        <Button to="/" size={ButtonSize.Large}>See Docs</Button>
+        <Button to="/" size={ButtonSize.Large}>Read More</Button>
       </div>
     </div>
     <div className={styles.panel}>
@@ -41,7 +41,7 @@ const ResourcesPanels: FunctionComponent = () => (
         </p>
       </div>
       <div className={styles.buttonContainer}>
-        <Button to="/" size={ButtonSize.Large}>See Docs</Button>
+        <Button to="/" size={ButtonSize.Large}>Read More</Button>
       </div>
     </div>
     <div className={styles.panel}>
@@ -60,7 +60,7 @@ const ResourcesPanels: FunctionComponent = () => (
         </p>
       </div>
       <div className={styles.buttonContainer}>
-        <Button to="/" size={ButtonSize.Large}>See Docs</Button>
+        <Button to="/" size={ButtonSize.Large}>Read More</Button>
       </div>
     </div>
   </div>


### PR DESCRIPTION

The 'ResourcesPanels' component originally had 'See Docs' as the label for multiple buttons leading to different resources. This description was vague considering the diversity of the resources (PDFs, blog articles, educational docs). The pull request updates the button labels to 'Read More' to provide more clarity and accuracy, improving user experience.

- Updates the button text for readability and user guidance in the ResourcesPanels component.
- Each button label is changed from 'See Docs' to 'Read More' to better reflect the action for different types of resources.
