### PR TITLE
Refactored 'JobOpeningCard' to Utilize useMemo for ButtonSize Calculation

### DIFF
--- a/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
+++ b/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import Button, { ButtonSize } from '../../../Button/Button';
 import useIsMobileWidth from '../../../../hooks/useIsMobileWidth';
 import styles from './JobOpeningCard.scss';
@@ -18,7 +18,8 @@ const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
   url,
 }) => {
   const isMobileWidth = useIsMobileWidth();
-  const buttonSize = isMobileWidth ? ButtonSize.Small : ButtonSize.Medium;
+  const buttonSize = useMemo(() => (isMobileWidth ? ButtonSize.Small : ButtonSize.Medium), [isMobileWidth]);
+
   return (
     <div className={styles.container}>
       <div className={styles.text}>


### PR DESCRIPTION

To avoid recalculations of the buttonSize on each render, we can leverage React's useMemo hook, which will only recompute the buttonSize when isMobileWidth changes. This is a valuable change as it optimizes the component's performance, particularly during rapid state changes or re-renders that might be caused by parent components.
