### PR TITLE
Refactor duplication check in ForgotPassword handleSubmit function

### DIFF
--- a/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
+++ b/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
@@ -58,9 +58,6 @@ const ForgotPassword: FunctionComponent = () => {
         throw new Error('success variable not type boolean: ForgotPassword.tsx');
       }
 
-      if (typeof result.success !== 'boolean') {
-        throw new Error('success variable not type boolean: ForgotPassword.tsx');
-      }
       if (result.success) {
         setShowSuccessPopup(true);
       } else {


### PR DESCRIPTION

The handleSubmit function in ForgotPassword component currently checks the type of result.success twice, which appears to be a duplication error. This small PR eliminates the redundant check for a cleaner and more efficient codebase. This is a good practice to avoid potential confusion in future code reviews or maintenance.

Refactoring here not only improves code quality and readability but also prevents any misunderstandings that could arise from a seemingly duplicated check, which could be misinterpreted as an indicator of a more complex logic or a misunderstanding of the existing code.
