### PR TITLE
Refactor `generateSalt` Function for Improved Promise Handling

### DIFF
--- a/src/server/common/utilities/crypto.ts
+++ b/src/server/common/utilities/crypto.ts
@@ -1,4 +1,5 @@
-import crypt from 'crypto';
+import crypt, { randomBytes } from 'crypto';
+import { promisify } from 'util';
 
 // TODO: determine an appropriate number
 const HASH_ROUNDS = 500;
@@ -7,16 +8,8 @@ export const hash = (input: Buffer): Buffer => {
   const result = crypt.createHash('sha256').update(input).digest();
   return result;
 };
-// changed from 256 to 128: salt.toString(hex) returns 512 char
-export const generateSalt
-= async(): Promise<Buffer> => new Promise((resolve, reject) => {
-  crypt.randomBytes(128, (err, buf) => {
-    if (err !== null) {
-      reject(err);
-    }
-    resolve(buf);
-  });
-});
+// Use promisify to simplify Promise-based usage of crypto.randomBytes
+export const generateSalt = promisify(randomBytes);
 
 export const saltAndHash = (password: string, salt: Buffer): Buffer => {
   const bufferPassword = Buffer.from(password);


### PR DESCRIPTION

The refactoring includes replacing the traditional Promise constructor in the `generateSalt` function with a util.promisify approach. This change simplifies the function by removing the boilerplate manual promise construction code and leverages the built-in `util.promisify` to automatically convert the `crypto.randomBytes` callback-based API to return a `Promise`, resulting in more concise and modern code. Moreover, the promisified function checks nullity check of `err` internally, removing the need for an extra check.
