### PR TITLE
Refactor useChangeHandler to Simplify Conditionals and Element Check

### DIFF
--- a/src/client/hooks/useChangeHandler.ts
+++ b/src/client/hooks/useChangeHandler.ts
@@ -3,17 +3,11 @@ import type { ChangeEvent } from 'react';
 import logger from '../../server/logger';
 
 type SetterCallback = (value: string) => void;
-type ChangeHandler = (e: ChangeEvent<HTMLSelectElement>) => void;
 
-const useChangeHandler = (setterCallback: SetterCallback): ChangeHandler => {
-  const changeHandler: ChangeHandler = (e) => {
+const useChangeHandler = (setterCallback: SetterCallback) => {
+  const changeHandler = (e: ChangeEvent<HTMLSelectElement>) => {
     e.preventDefault();
-    const { target } = e;
-    if (target instanceof HTMLSelectElement) {
-      setterCallback(e.target.value);
-    } else {
-      logger.info('type error in TimeDropdown: handleValueChange');
-    }
+    setterCallback(e.target.value);
   };
   return useCallback(changeHandler, [setterCallback]);
 };


### PR DESCRIPTION

The current implementation of useChangeHandler includes an unnecessary check to determine if the target of an event is an instance of HTMLSelectElement, as the type of the event is already ChangeEvent<HTMLSelectElement>, which guarantees the target to be a select element. This refactor simplifies the conditional and removes the redundant instance check, leading to cleaner and more efficient code.

By avoiding the irrelevant type checking, we reduce the complexity of the function and ensure that TypeScript's static typing advantages are fully leveraged. This change also eliminates a scenario where the logger emits a type error, decreasing potential noise in our logging. The change is small but enhances maintainability and embraces the type safety provided by TypeScript.
