### PR TITLE
Refactor 'AdminPortalPage' to DRY Meta Tags with a Reusable Component

### DIFF
--- a/src/client/pages/AdminPortal/AdminPortalPage.tsx
+++ b/src/client/pages/AdminPortal/AdminPortalPage.tsx
@@ -8,17 +8,21 @@ import ManageUsers from '../../components/ManageUsers/ManageUsers';
 import ResetPassword from '../../components/ResetPassword/ResetPassword';
 import ManageProjects from '../../components/MangageProjects/ManageProjects';
 
+const MetaTags: FunctionComponent = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Admin Portal-Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/work-portal" />
+    <meta
+      name="description"
+      content="Hours of all employees of Sunny Software LLC"
+    />
+  </Helmet>
+);
+
 const AdminPortalPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Admin Portal-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/work-portal" />
-      <meta
-        name="description"
-        content="Hours of all employees of Sunny Software LLC"
-      />
-    </Helmet>
+    <MetaTags />
     <h1>Admin Portal</h1>
     <ManageProjects />
     <ResetPassword />


### PR DESCRIPTION

To enhance code maintainability and prevent repetitive code, I suggest refactoring the 'AdminPortalPage' by extracting the repeated Helmet meta tags into a reusable component. This not only ensures that any updates to our meta tags in the future are made in one place, but also makes our AdminPortalPage more concise and clear on its intent.

By encapsulating the meta tag configuration into a separate component, we adhere to the DRY (Don’t Repeat Yourself) principle, which is a best practice in software development, to minimize code repetition and potential errors.
