### PR TITLE
Refactor eleventh logger import to utilize LogLevel directly instead of import all

### DIFF
--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,5 +1,5 @@
-import logger, { LogLevel } from 'eleventh';
+import { LogLevel, setLogLevel } from 'eleventh';
 
-logger.setLogLevel(LogLevel.debug);
+setLogLevel(LogLevel.debug);
 
-export default logger;
+export { setLogLevel as default, LogLevel };


### PR DESCRIPTION

To avoid importing the entire 'eleventh' module when we only need the LogLevel enum, I've refactored the code to import LogLevel directly. This can help with tree-shaking and potentially reduce the final bundle size if the 'eleventh' module is large and only parts of it are used. Additionally, namespaced imports can sometimes improve clarity about what is being used from a module.
