### PR TITLE
Extract Helmet MetaData to Improve Code Reusability

### DIFF
--- a/src/client/pages/ResourcesPage/ResourcesPage.tsx
+++ b/src/client/pages/ResourcesPage/ResourcesPage.tsx
@@ -4,17 +4,21 @@ import { Helmet } from 'react-helmet';
 import ResourcesBanner from '../../components/ResourcesPage/ResourcesBanner/ResourcesBanner';
 import ResourcesPanels from '../../components/ResourcesPage/ResourcesPanels/ResourcesPanels';
 
+const MetaData: FunctionComponent = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Portfolio-Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/resources" />
+    <meta
+      name="description"
+      content="Portfolio of projects done by Sunny Software LLC"
+    />
+  </Helmet>
+);
+
 const ResourcesPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Portfolio-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/resources" />
-      <meta
-        name="description"
-        content="Portfolio of projects done by Sunny Software LLC"
-      />
-    </Helmet>
+    <MetaData />
     <ResourcesBanner />
     <ResourcesPanels />
   </div>


### PR DESCRIPTION

I am proposing the extraction of the Helmet component configuration into a reusable React component. This refactor will allow us to encapsulate the metadata setup for the page, making our ResourcesPage component more focused and improving code reusability. The newly created MetaData component can then be reused across different pages with minimal changes.
