### PR TITLE
Rename incorrectly spelled 'crypto' image file imports in Services Component for clarity

### DIFF
--- a/src/client/components/Services/Services.tsx
+++ b/src/client/components/Services/Services.tsx
@@ -10,15 +10,15 @@ import mobileMiddleLeftBottom from './mobileEmptySignupImage.jpg';
 import mobileMiddleRightTop from './mobileSignupFilledImage.jpg';
 import mobileMiddleRightBottom from './mobileExpenseGraphImage.jpg';
 import mobileRight from './mobileQrCodeImage.jpg';
-import cryptoImg1 from './cyrptoImage1.jpg';
-import cryptoImg2 from './cyrptoImage2.jpg';
+import cryptoImg1 from './cryptoImage1.jpg';
+import cryptoImg2 from './cryptoImage2.jpg';
 
 const Services: FunctionComponent = () => (
   <div className={styles.servicesContainer}>
     <div className={styles.servicesTextCard}>
       <h2>Save time and get more done</h2>
       <p>
-        Our mission is to become an extension of yoru team so we can
+        Our mission is to become an extension of your team so we can
         help your business grow - all while costing you less than a full-time
         developer.
       </p>


### PR DESCRIPTION

During a review of the Services TypeScript file, I noticed that the file imports for the crypto images were incorrectly spelled as 'cyrptoImage1.jpg' and 'cyrptoImage2.jpg'. Renaming these imports enhances code readability and eliminates potential confusion for future maintenance or development in this codebase.

This change is minor but important for maintaining a professional and error-free codebase. As there is a common tendency for further development or debugging to reference these filenames, it is essential that they are named correctly to prevent any misunderstandings or mishaps.
