### PR TITLE
Encapsulate Navigation Logic in useEffect for ResetPasswordPage

### DIFF
--- a/src/client/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/client/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import type { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import logo from '../../static/images/Logo.png';
 import loginPhoto from '../../static/images/LoginPhoto.png';
@@ -12,9 +11,12 @@ import styles from './ResetPasswordPage.scss';
 const ResetPasswordPage: FunctionComponent = () => {
   const navigate = useNavigate();
   const loggedIn = useSelector(getLoggedIn);
-  if (loggedIn) {
-    navigate('/');
-  }
+
+  useEffect(() => {
+    if (loggedIn) {
+      navigate('/');
+    }
+  }, [loggedIn, navigate]);
 
   return (
     <div className={styles.pageContainer}>


### PR DESCRIPTION

Moving the navigation logic inside useEffect in ResetPasswordPage for better compliance with React's side effects paradigm. The current direct call to navigate within the function component body can lead to unintended behavior in React's strict mode or during concurrent rendering phases. To ensure the navigation occurs only after the component renders and React updates the DOM, we will encapsulate the navigation logic within a useEffect hook. This guarantees that the check for logged-in status and potential redirect only occurs after the component mounts, providing a more predictable and side-effect management following React's data flow.
