### PR TITLE
Encapsulate MetaData and Content in 'ContactUsPage' Component for Readability

### DIFF
--- a/src/client/pages/ContactUs/ContactUsPage.tsx
+++ b/src/client/pages/ContactUs/ContactUsPage.tsx
@@ -4,34 +4,37 @@ import { Helmet } from 'react-helmet';
 import ContactForm from '../../components/ContactForm/ContactForm';
 import styles from './ContactUsPage.scss';
 
+const PageMetaData: FunctionComponent = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Contact Us-Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/contact-us" />
+    <meta name="description" content="Contact information page for Sunny Software LLC" />
+  </Helmet>
+);
+
+const ContactInfoContent: FunctionComponent = () => (
+  <div className={styles.textContainer}>
+    <h2>Contact us</h2>
+    <div className={styles.contactInfoSection}>
+      <h3>Email:</h3>
+      <p>trevinhofmann@gmail.com</p>
+    </div>
+    <div className={styles.contactInfoSection}>
+      <h3>Phone:</h3>
+      <p>(715) 350-9696</p>
+    </div>
+    <div className={styles.contactInfoSection}>
+      <h3>Office address</h3>
+      <p>Chicago HQ Estica Cop. Macomb, MI 48042</p>
+    </div>
+  </div>
+);
+
 const ContactUsPage: FunctionComponent = () => (
   <div className={styles.container}>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Contact Us-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/contact-us" />
-      <meta
-        name="description"
-        content="Contact information page for Sunny Software LLC"
-      />
-    </Helmet>
-
-    <div className={styles.textContainer}>
-      <h2>Contact us</h2>
-      <div className={styles.contactInfoSection}>
-        <h3>Email:</h3>
-        <p>trevinhofmann@gmail.com</p>
-      </div>
-      <div className={styles.contactInfoSection}>
-        <h3>Phone:</h3>
-        <p>(715) 350-9696</p>
-      </div>
-      <div className={styles.contactInfoSection}>
-        <h3>Office address</h3>
-        <p>Chicago HQ Estica Cop. Macomb, MI 48042</p>
-      </div>
-
-    </div>
+    <PageMetaData />
+    <ContactInfoContent />
     <ContactForm />
   </div>
 );


### PR DESCRIPTION

This change introduces more structure to the 'ContactUsPage' component by defining two smaller components: 'PageMetaData' and 'ContactInfoContent'. 'PageMetaData' encapsulates the meta tags information associated with the page, enhancing separation of concerns, and making 'ContactUsPage' easier to read and maintain. 'ContactInfoContent' groups the contact information sections together, improving the readability of the content structure and enabling easier updates to contact details in the future.
