### PR TITLE
Optimize 'ShowNavBar' logic to handle navigation bar visibility based on pathnames

### DIFF
--- a/src/client/components/ShowNavBar/ShowNavBar.tsx
+++ b/src/client/components/ShowNavBar/ShowNavBar.tsx
@@ -5,20 +5,20 @@ interface IProps {
   children: React.JSX.Element;
 }
 
-const ShowNavBar
-= ({ children }: IProps): React.JSX.Element => {
+const noNavBarRoutes = new Set([
+  '/login',
+  '/login/forgot-password',
+  '/login/reset-password',
+]);
+
+const ShowNavBar = ({ children }: IProps): React.JSX.Element => {
   const [showNavBar, setShowNavBar] = useState(true);
   const locationPath = useLocation();
 
   useEffect(() => {
-    if (locationPath.pathname === '/login'
-      || locationPath.pathname === '/login/forgot-password'
-      || locationPath.pathname === '/login/reset-password') {
-      setShowNavBar(false);
-    } else {
-      setShowNavBar(true);
-    }
+    setShowNavBar(!noNavBarRoutes.has(locationPath.pathname));
   }, [locationPath]);
+
   return (
     <div>{showNavBar && children}</div>
   );


### PR DESCRIPTION

The 'ShowNavBar' component's useEffect hook has been refactored to use a more concise approach for determining whether to show the navigation bar or not, based on the current pathname. Instead of using multiple 'or' conditions, the pathnames have been placed in a Set for more efficient checking. This enhances readability and slightly improves performance, as Set accesses are typically faster than array searches, especially as the list of pathnames grows.
