### PR TITLE
Rename 'openClosePanel' to 'togglePanel' for AccordianPanel for Clarity

### DIFF
--- a/src/client/components/AccordianPanel/AccordianPanel.tsx
+++ b/src/client/components/AccordianPanel/AccordianPanel.tsx
@@ -10,12 +10,12 @@ type AccordianPanelProps = {
 const AccordianPanel: FunctionComponent<AccordianPanelProps>
  = ({ question, answer }) => {
    const [isOpen, setIsOpen] = useState(false);
-   const openClosePanel = useCallback(() => {
+   const togglePanel = useCallback(() => {
      setIsOpen(!isOpen);
    }, [isOpen]);
    return (
      <div className={styles.accordianPanelContainer}>
-       <div className={styles.accordianQuestion} onClick={openClosePanel}>
+       <div className={styles.accordianQuestion} onClick={togglePanel}>
          <h3>{question}</h3>
          <div className={styles.panelArrow}>
            {'>'}


### PR DESCRIPTION

The change renames the 'openClosePanel' callback function to 'togglePanel' within the AccordianPanel component. This provides better readability and immediately suggests the function's purpose—to toggle the state of the panel. The new name follows common naming conventions for boolean state toggling functions, making the code more intuitive for future maintainers or contributors.

This refactoring does not alter the functionality of the component but is a small yet meaningful improvement in terms of code clarity.
