### PR TITLE
Rename 'IProps' to 'AdminPrivateRouteProps' for Better Clarity

### DIFF
--- a/src/client/components/PrivateRoutes/AdminPrivateRoute.tsx
+++ b/src/client/components/PrivateRoutes/AdminPrivateRoute.tsx
@@ -3,11 +3,11 @@ import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
 import { getIsAdmin } from '../../redux/selectors/account';
 
-interface IProps {
+interface AdminPrivateRouteProps {
   children: React.JSX.Element;
 }
 
-const AdminPrivateRoute = ({ children }: IProps): React.JSX.Element => {
+const AdminPrivateRoute = ({ children }: AdminPrivateRouteProps): React.JSX.Element => {
   const isAdmin = useSelector(getIsAdmin);
   if (!isAdmin) {
     return <Navigate to="/login" />;


### PR DESCRIPTION

Refactoring the TypeScript file includes renaming the 'IProps' interface for the 'AdminPrivateRoute' component to 'AdminPrivateRouteProps' to enhance readability and clarity of the code. The name 'IProps' is nonspecific and does not communicate the intended use of the interface within the context of the 'AdminPrivateRoute' component. Using a more descriptive name makes the code easier to understand and maintain, especially for developers who might be new to the codebase or return to it after some time.
