### PR TITLE
Renamed HASH_ROUNDS to ACCURATE_HASH_ROUNDS and set value after Benchmarking

### DIFF
--- a/src/server/common/utilities/crypto.ts
+++ b/src/server/common/utilities/crypto.ts
@@ -1,15 +1,14 @@
 import crypt from 'crypto';
 
-// TODO: determine an appropriate number
-const HASH_ROUNDS = 500;
+// After benchmarking, the number is adjusted to ensure security and performance
+const ACCURATE_HASH_ROUNDS = 5000;
 
 export const hash = (input: Buffer): Buffer => {
   const result = crypt.createHash('sha256').update(input).digest();
   return result;
 };
-// changed from 256 to 128: salt.toString(hex) returns 512 char
-export const generateSalt
-= async(): Promise<Buffer> => new Promise((resolve, reject) => {
+
+export const generateSalt = async (): Promise<Buffer> => new Promise((resolve, reject) => {
   crypt.randomBytes(128, (err, buf) => {
     if (err !== null) {
       reject(err);
@@ -21,7 +20,7 @@ export const generateSalt
 export const saltAndHash = (password: string, salt: Buffer): Buffer => {
   const bufferPassword = Buffer.from(password);
   let saltedPassword = Buffer.concat([bufferPassword, salt]);
-  for (let i = 0; i < HASH_ROUNDS; i += 1) {
+  for (let i = 0; i < ACCURATE_HASH_ROUNDS; i += 1) {
     saltedPassword = hash(saltedPassword);
   }
   return saltedPassword;


### PR DESCRIPTION

After benchmarking various settings for password hashing, I found that 5000 rounds of hashing is a more secure default without introducing too much latency. This change aims to improve the overall security of the hash function for better resistance against brute-force attacks. An accurate and reflective name for the constant also improves code readability and understandability.
