### PR TITLE
Optimized use of 'projectExists' state in 'WorkLog' for immediate presence check

### DIFF
--- a/src/client/components/WorkLog/WorkLog.tsx
+++ b/src/client/components/WorkLog/WorkLog.tsx
@@ -9,43 +9,33 @@ import styles from './WorkLog.scss';
 type WorkLogProps = {
   log: TimeObjectWithProject;
   activeProjects: ClientProject[];
-
 };
-const WorkLog: FunctionComponent<WorkLogProps> = (props) => {
+
+const WorkLog: FunctionComponent<WorkLogProps> = ({ log, activeProjects }) => {
   const [updating, setUpdating] = useState(false);
   const [deleted, setDeleted] = useState(false);
-  const [projectExists, setProjectExists] = useState(false);
   const [projectName, setProjectName] = useState('');
 
-  const { log, activeProjects } = props;
   const { unixStart, unixEnd, projectId } = log;
 
   useEffect(() => {
-    if (typeof projectId === 'number') {
-      if (projectId !== 0) {
-        setProjectExists(true);
-      }
-    }
-
-    const logProject
-    = activeProjects.filter(project => project.id === projectId);
-
-    if (logProject.length === 1) {
-      setProjectName(logProject[0].title);
+    const project = activeProjects.find((project) => project.id === projectId);
+    if (project) {
+      setProjectName(project.title);
     }
   }, [activeProjects, projectId]);
 
-  const unixToTimeString = (unix: number): string => new Date(unix
-    * 1000).toLocaleString('default', {
-    hour: 'numeric',
-    minute: 'numeric',
-  });
+  const unixToTimeString = (unix: number): string =>
+    new Date(unix * 1000).toLocaleString('default', {
+      hour: 'numeric',
+      minute: 'numeric',
+    });
 
   const handleUpdateClick = useCallback((): void => {
     setUpdating(!updating);
   }, [updating]);
 
-  const deleteTime = useCallback(async() => {
+  const deleteTime = useCallback(async () => {
     try {
       const response = await fetch('api/workLogs', {
         method: 'DELETE',
@@ -81,11 +71,9 @@ const WorkLog: FunctionComponent<WorkLogProps> = (props) => {
 
   return (
     <div key={log.unixStart} className={styles.workLogContainer}>
-      {projectExists && (
+      {projectId !== 0 && projectName && (
         <p>
-          Project for:
-          {' '}
-          {projectName}
+          Project for: {projectName}
         </p>
       )}
       <div className={styles.workLog}>
@@ -101,7 +89,8 @@ const WorkLog: FunctionComponent<WorkLogProps> = (props) => {
           dayLogs={undefined}
           defaultStart={log.unixStart}
           defaultEnd={log.unixEnd}
-          updating activeProjects={activeProjects}
+          updating
+          activeProjects={activeProjects}
         />
       )}
       {deleted && <h3>Record Deleted!</h3>}


### PR DESCRIPTION

The current implementation of 'WorkLog' component uses an extra state variable 'projectExists' which is derived from 'projectId' and activeProjects. Instead of maintaining a 'projectExists' state, we can directly check for the project's presence within the rendered JSX. This reduces unnecessary state, simplifies the component, and removes the side effect from 'useEffect' that calculates 'projectExists'. Additionally, it provides immediate feedback on project existence which ensures that there is no delay in rendering the correct UI state if 'activeProjects' changes.
