### PR TITLE
Rename 'subject' to 'text' for Role input type to correct HTML standard

### DIFF
--- a/src/client/components/EditUser/EditUser.tsx
+++ b/src/client/components/EditUser/EditUser.tsx
@@ -119,7 +119,7 @@ const EditUser: FunctionComponent<UserIdNameEmailRole> = (props) => {
         <label className="label">Role</label>
         <input
           onChange={handleRoleChange} className="input"
-          value={newRole} type="subject"
+          value={newRole} type="text"
         />
         <button
           onClick={handleSubmit}


### PR DESCRIPTION

The 'type' attribute for the Role input field was incorrectly set to 'subject', which is not a valid value according to HTML standards. Thus, I refactored the 'type' attribute of the Role input field to use 'text' to conform to the appropriate HTML input type and ensure proper validation and behavior of the input field.
