### PR TITLE
Rename 'authenticationToken' check error message for clarity

### DIFF
--- a/src/server/html.ts
+++ b/src/server/html.ts
@@ -39,7 +39,7 @@ export default (req: ExpressRequest, res: ExpressResponse): void => {
     try {
       const { authenticationToken } = req.cookies;
       if (typeof authenticationToken !== 'string') {
-        throw new Error('api/authenticate: userToken not type string');
+        throw new Error('Expected authenticationToken to be a string');
       }
       const tokenActive = await checkActiveToken(authenticationToken);
       if (!tokenActive) {


### PR DESCRIPTION

The current error message used when 'authenticationToken' is not of type string can cause confusion, as it points to a nonexistent API path "api/authenticate". This PR changes the error message to be more generic and accurately indicate the cause of the error.

This change does not alter any logic but makes the error message more understandable for developers who may encounter this issue during debugging.
