### PR TITLE
Optimize 'ShowNavBar' by Reducing State Management Overhead

### DIFF
--- a/src/client/components/ShowNavBar/ShowNavBar.tsx
+++ b/src/client/components/ShowNavBar/ShowNavBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 interface IProps {
@@ -12,12 +12,8 @@ const noNavBarRoutes = new Set([
 ]);
 
 const ShowNavBar = ({ children }: IProps): React.JSX.Element => {
-  const [showNavBar, setShowNavBar] = useState(true);
   const locationPath = useLocation();
-
-  useEffect(() => {
-    setShowNavBar(!noNavBarRoutes.has(locationPath.pathname));
-  }, [locationPath]);
+  const showNavBar = !noNavBarRoutes.has(locationPath.pathname);
 
   return (
     <div>{showNavBar && children}</div>


### PR DESCRIPTION
Refactoring the 'ShowNavBar' component to eliminate unnecessary state and re-rendering by directly calculating the visibility of the navbar based on the current location. By removing the useState hook and the useEffect reliance, we decrease the component's complexity, enhance performance by reducing the workload of the React reconciler, and cut down on potential re-rendering occurrences. This change leads to leaner and more efficient code.