### PR TITLE
Introduce 'ButtonProps' to Optimize 'ServicesNeedHelp' Component

### DIFF
--- a/src/client/components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp.tsx
+++ b/src/client/components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp.tsx
@@ -3,20 +3,28 @@ import React from 'react';
 import Button, { ButtonSize, ButtonVariant } from '../../Button/Button';
 import styles from './ServicesNeedHelp.scss';
 
-const ServicesNeedHelp: FunctionComponent = () => (
-  <div className={styles.container}>
-    <div className={styles.text}>
-      <h2>We provide best services. Need help?</h2>
-      <p>
-        Our mission is to become an extension of your
-        team so we can help your business grow — all
-        while costing you less than a single full-time designer.
-      </p>
+const ServicesNeedHelp: FunctionComponent = () => {
+  const buttonProps = {
+    size: ButtonSize.Large,
+    variant: ButtonVariant.Outlined,
+    to: "./contact-us",
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.text}>
+        <h2>We provide best services. Need help?</h2>
+        <p>
+          Our mission is to become an extension of your
+          team so we can help your business grow — all
+          while costing you less than a single full-time designer.
+        </p>
+      </div>
+      <Button {...buttonProps}>
+        Get a Quote
+      </Button>
     </div>
-    <Button size={ButtonSize.Large} variant={ButtonVariant.Outlined} to="./contact-us">
-      Get a Quote
-    </Button>
-  </div>
-);
+  );
+};
 
 export default ServicesNeedHelp;


### PR DESCRIPTION

The current implementation of 'ServicesNeedHelp' component directly passes 'ButtonSize' and 'ButtonVariant' props within the render function. To improve scalability and prevent potential redundancy if the 'Button' component is used multiple times in the 'ServicesNeedHelp' component, we will define a constant 'buttonProps' outside the render function. This change makes it easy to adjust Button properties at a single location and promotes cleaner code by reducing inline prop definitions.

This refactor is valuable as it:
- Centralizes button properties, enabling easier updates and maintenance.
- Streamlines the JSX within the 'ServicesNeedHelp' render function, enhancing code readability.
- Prepares the codebase for potential future extensions where more button instances with similar properties might be needed.
