### PR TITLE
Optimized Date Calculation in 'EmployeeWorkCalendars' for Boundary Week Day Fixes

### DIFF
--- a/src/client/components/EmployeeWorkCalendars/EmployeeWorkCalendars.tsx
+++ b/src/client/components/EmployeeWorkCalendars/EmployeeWorkCalendars.tsx
@@ -11,11 +11,10 @@ const EmployeeWorkCalendars: FunctionComponent = () => {
 
   const getDaysInWeek = useCallback((): Date[] => {
     const days: Date[] = [];
+    const startOfWeek = currentDate.getDate() - currentDate.getDay();
     for (let i = 0; i < 7; i++) {
-      const first = currentDate.getDate() - currentDate.getDay() + i;
-      const day
-      = new Date(currentDate.setDate(first));
-      days.push(day);
+      const weekDay = new Date(currentDate.getFullYear(), currentDate.getMonth(), startOfWeek + i);
+      days.push(weekDay);
     }
     return days;
   }, [currentDate]);
@@ -23,21 +22,15 @@ const EmployeeWorkCalendars: FunctionComponent = () => {
   const daysInWeek = useMemo(() => getDaysInWeek(), [getDaysInWeek]);
 
   const getUnixDayStart = (date: Date): number => {
-    date.setHours(0);
-    date.setMinutes(0);
-    date.setSeconds(0);
-    date.setMilliseconds(0);
-
-    return Math.floor(date.getTime() / 1000);
+    const copiedDate = new Date(date.getTime());
+    copiedDate.setHours(0, 0, 0, 0);
+    return Math.floor(copiedDate.getTime() / 1000);
   };
 
   const getUnixDayEnd = (date: Date): number => {
-    date.setHours(23);
-    date.setMinutes(59);
-    date.setSeconds(59);
-    date.setMilliseconds(999);
-
-    return Math.floor(date.getTime() / 1000);
+    const copiedDate = new Date(date.getTime());
+    copiedDate.setHours(23, 59, 59, 999);
+    return Math.floor(copiedDate.getTime() / 1000);
   };
 
   const fetchAllWeekLogs = useCallback(async() => {
@@ -83,19 +76,13 @@ const EmployeeWorkCalendars: FunctionComponent = () => {
 
   const changeToPreviousWeek = useCallback((): void => {
     setCurrentDate((currDate: Date): Date => {
-      const Year = currDate.getFullYear();
-      const Month = currDate.getMonth();
-      const Day = currDate.getDate();
-      return new Date(Year, Month, Day - 7);
+      return new Date(currDate.getFullYear(), currDate.getMonth(), currDate.getDate() - 7);
     });
   }, []);
 
   const changeToNextWeek = useCallback((): void => {
     setCurrentDate((currDate: Date): Date => {
-      const Year = currDate.getFullYear();
-      const Month = currDate.getMonth();
-      const Day = currDate.getDate();
-      return new Date(Year, Month, Day + 7);
+      return new Date(currDate.getFullYear(), currDate.getMonth(), currDate.getDate() + 7);
     });
   }, []);
 


### PR DESCRIPTION

The existing implementation of `getDaysInWeek` function in the `EmployeeWorkCalendars` component modifies the state-held `currentDate` which can lead to unexpected bugs, especially when navigating weeks. It indirectly affects the `currentDate` state due to JavaScript Date's mutable nature. To improve reliability, I've refactored the `getDaysInWeek` function to create a new Date instance without altering the `currentDate` state. This change enhances the predictability of week navigation functionality and assures that the calculated days for the displayed week are consistent.
