### PR TITLE
Provide TypeScript Type Annotation for Redux `reducer`

### DIFF
--- a/src/client/redux/slices/index.ts
+++ b/src/client/redux/slices/index.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from 'redux';
+import { combineReducers, Reducer } from 'redux';
 import account from './account';
+import { RootState } from './types'; // Assuming `RootState` is defined in './types'
 
-export const reducer = combineReducers({
+export const reducer: Reducer<RootState> = combineReducers({
   account,
 });


### PR DESCRIPTION

The current TypeScript file defines a Redux combined reducer without explicit type annotations. This leads to less predictable type inference that can cause issues during the development process. By adding a type annotation to `reducer`, developers working on the project will have immediate insight into the structure of the state in the store, improving code reliability and maintainability.

This change provides better developer tooling support and can prevent potential errors by enabling stricter type checking.
