### PR TITLE
Refactor Meta Tags into a Reusable Helmet Component for MethodologyPage

### DIFF
--- a/src/client/pages/MethodologyPage/MethodologyPage.tsx
+++ b/src/client/pages/MethodologyPage/MethodologyPage.tsx
@@ -6,17 +6,18 @@ import MethodologyFullList from '../../components/MethodologyPage/MethodologyFul
 import MethodologyBenefits from '../../components/MethodologyPage/MethodologyBenefits/MethodologyBenefits';
 import MethodologyNeedHelp from '../../components/MethodologyPage/MethodologyNeedHelp/MethodologyNeedHelp';
 
+const MethodologyPageHelmet: FunctionComponent = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Methodology-Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/methodology" />
+    <meta name="description" content="The methodology of Sunny Software LLC" />
+  </Helmet>
+);
+
 const MethodologyPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Methodology-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/methodology" />
-      <meta
-        name="description"
-        content="The methodology of Sunny Software LLC"
-      />
-    </Helmet>
+    <MethodologyPageHelmet />
     <MethodologyBanner />
     <MethodologyFullList />
     <MethodologyBenefits />


### PR DESCRIPTION

To enhance legibility and maintainability, the existing inline meta tag definitions within the MethodologyPage component have been refactored into a separate reusable component called MethodologyPageHelmet. This change encapsulates all head-related elements for the MethodologyPage within a distinct component, aiding future modifications or extensions involving meta tags or other head elements without cluttering the primary page component. This approach follows the best practices of component composition and separation of concerns in React development.

The addition of this component also sets a precedent for uniform handling of meta tags across different pages should the application architecture demand it in the future.
