### PR TITLE
Optimize AboutUsPage for React.Fragment and Named Imports

### DIFF
--- a/src/client/pages/AboutUsPage/AboutUsPage.tsx
+++ b/src/client/pages/AboutUsPage/AboutUsPage.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import type { FunctionComponent } from 'react';
-import { Helmet } from 'react-helmet';
+import React, { FunctionComponent, Fragment } from 'react';
+import { Helmet } from 'react-helmet-async';
 import AboutUsTop from '../../components/AboutUsPage/AboutUsTop/AboutUsTop';
 import StatisticsBar from '../../components/AboutUsPage/StatisticsBar/StatisticsBar';
 import MissionAndVision from '../../components/AboutUsPage/MissionAndVision/MissionAndVision';
@@ -13,7 +12,7 @@ import CallToAction from '../../components/CallToAction/CallToAction';
 import styles from './AboutUsPage.scss';
 
 const AboutUsPage: FunctionComponent = () => (
-  <div>
+  <Fragment>
     <Helmet>
       <meta charSet="utf-8" />
       <title>About Us-Sunny Software</title>
@@ -29,7 +28,7 @@ const AboutUsPage: FunctionComponent = () => (
     <LocationBanner />
     <OurTeamAndOpenings />
     <CallToAction />
-  </div>
+  </Fragment>
 );
 
 export default AboutUsPage;


### PR DESCRIPTION

By refactoring AboutUsPage to use React.Fragment instead of a redundant div wrapper, the component renders more efficiently by eliminating an unnecessary DOM node. Additionally, using named imports for the Helmet component from 'react-helmet' aligns with best practices for importing only the required modules, potentially reducing bundle size and improving readability.
