### PR TITLE
Optimized useWindowSize Hook with Debounce Functionality

### DIFF
--- a/src/client/hooks/useInnerWidth.ts
+++ b/src/client/hooks/useInnerWidth.ts
@@ -1,14 +1,23 @@
 import { useState, useEffect } from 'react';
 
-export default (): number => {
+function debounce(fn: Function, ms: number): () => void {
+  let timer: number;
+  return (): void => {
+    clearTimeout(timer);
+    timer = window.setTimeout(() => fn.apply(this, arguments), ms);
+  };
+}
+
+export default function useWindowSize(): number {
   const [width, setWidth] = useState(window.innerWidth);
 
   useEffect(() => {
-    const handleResize = (): void => {
+    const debouncedHandleResize = debounce(() => {
       setWidth(window.innerWidth);
-    };
-    window.addEventListener('resize', handleResize);
-    return (): void => window.removeEventListener('resize', handleResize);
+    }, 250);
+
+    window.addEventListener('resize', debouncedHandleResize);
+    return (): void => window.removeEventListener('resize', debouncedHandleResize);
   }, []);
 
   return width;


### PR DESCRIPTION

The code refactor provides an optimized custom React hook named useWindowSize that returns the current window width. The improvement includes implementing a debounce functionality, which prevents excessively frequent state updates on window resize. This enhancement reduces unnecessary renders, improving the performance of components that rely on window size.

- Debounce function delays the execution of setWidth until after a set amount of time has passed since the last window resize event.
- The hook is now named useWindowSize to better reflect its purpose.
- The hook is self-contained and includes TypeScript type annotations for clarity.
