### PR TITLE
Prevent Navigation Duplication in ResetPasswordPage upon User Login Status Check

### DIFF
--- a/src/client/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/client/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import type { FunctionComponent } from 'react';
@@ -12,9 +12,12 @@ import styles from './ResetPasswordPage.scss';
 const ResetPasswordPage: FunctionComponent = () => {
   const navigate = useNavigate();
   const loggedIn = useSelector(getLoggedIn);
-  if (loggedIn) {
-    navigate('/');
-  }
+
+  useEffect(() => {
+    if (loggedIn) {
+      navigate('/');
+    }
+  }, [loggedIn, navigate]);
 
   return (
     <div className={styles.pageContainer}>


### PR DESCRIPTION

The current implementation of the ResetPasswordPage component performs a navigation action upon component mount, without any condition that prevents potential navigation duplication. Navigation duplication can happen if the component updates and results in multiple history entries, which is not the desired behavior when checking the user's login status. To improve this, the code has been refactored to use React's useEffect hook, ensuring the navigation action is only performed once upon the component's initial mount. This change makes the component's behavior more predictable and guards against unintended navigation actions that could degrade user experience.
