### PR TITLE
Optimize Repeated Code in 'FullPortfolioList' by Creating Reusable Components

### DIFF
--- a/src/client/components/PortfolioPage/FullPortfolioList/FullPortfolioList.tsx
+++ b/src/client/components/PortfolioPage/FullPortfolioList/FullPortfolioList.tsx
@@ -4,105 +4,65 @@ import Button, { ButtonSize, ButtonVariant } from '../../Button/Button';
 import styles from './FullPortfolioList.scss';
 import projectImage from './projectImage.png';
 
-const FullPortfolioList: FunctionComponent = () => (
-  <div className={styles.container}>
-    <div className={styles.text}>
-      <h2>What we provide you?</h2>
-      <p>
-        Our mission is to become an extension
-        of your team so we can help your business
-        grow — all while costing you less than a
-        single full-time designer.
-      </p>
-    </div>
-    <div className={styles.portfolioCardsContainer}>
-      <div className={styles.projectContainer1}>
-        <div className={styles.projectOneText}>
-          <h3>Project 1</h3>
-          <p>
-            Manage, edit, and sync productinformation across
-            all your . nc productinformation across all your .
-            Manage, edit, and sync productinformation across
-            all your Manage, edit, and sync productinformation
-            across all your . nc productinformation across all
-            your .Manage, edit, and sync productinformation across all your .
-          </p>
-          <Button
-            size={ButtonSize.Large}
-            variant={ButtonVariant.Outlined}
-            to="/contact-us"
-          >
-            See more
-          </Button>
-        </div>
-        <img src={projectImage} alt="picture of sunny software project" />
-      </div>
-      <div className={styles.projectContainer2}>
-        <div className={styles.projectTwoText}>
-          <h3>Project 1</h3>
-          <p>
-            Manage, edit, and sync productinformation across all your
-            . nc productinformation across all your .Manage, edit, an
-            d sync productinformation across all your Manage, edit,
-            and sync productinformation across all your . nc product
-            information across all your .Manage, edit, and sync
-            productinformation across all your .
-          </p>
-          <Button
-            size={ButtonSize.Large}
-            variant={ButtonVariant.Outlined}
-            to="/contact-us"
-          >
-            See more
-          </Button>
-        </div>
-        <img src={projectImage} alt="picture of sunny software project" />
-      </div>
-      <div className={styles.projectContainer1}>
-        <div className={styles.projectOneText}>
-          <h3>Project 1</h3>
-          <p>
-            Manage, edit, and sync productinformation across all your
-            . nc productinformation across all your .Manage, edit,
-            and sync productinformation across all your Manage, edit,
-            and sync productinformation across all your . nc product
-            information across all your .Manage, edit, and sync prod
-            uctinformation across all your .
-          </p>
-          <Button
-            size={ButtonSize.Large}
-            variant={ButtonVariant.Outlined}
-            to="/contact-us"
-          >
-            See more
-          </Button>
-        </div>
-        <img src={projectImage} alt="picture of sunny software project" />
-      </div>
-      <div className={styles.projectContainer2}>
-        <div className={styles.projectTwoText}>
-          <h3>Project 1</h3>
-          <p>
-            Manage, edit, and sync productinformation across all your
-            . nc productinformation across all your .Manage, edit,
-            and sync productinformation across all your Manage, edit,
-            and sync productinformation across all your . nc
-            productinformation across all your .Manage, edit,
-            and sync productinformation across all your .
-          </p>
-          <Button
-            size={ButtonSize.Large}
-            variant={ButtonVariant.Outlined}
-            to="/contact-us"
-          >
-            See more
-          </Button>
-        </div>
-        <img src={projectImage} alt="picture of sunny software project" />
-      </div>
+interface PortfolioCardProps {
+  title: string;
+  description: string;
+  image: string;
+  imageAlt: string;
+}
 
+const PortfolioCard: FunctionComponent<PortfolioCardProps> = ({ title, description, image, imageAlt }) => (
+  <div className={styles.projectContainer}>
+    <div className={styles.projectText}>
+      <h3>{title}</h3>
+      <p>{description}</p>
+      <Button
+        size={ButtonSize.Large}
+        variant={ButtonVariant.Outlined}
+        to="/contact-us"
+      >
+        See more
+      </Button>
     </div>
+    <img src={image} alt={imageAlt} />
   </div>
 );
+
+const FullPortfolioList: FunctionComponent = () => {
+  const projectsList = [
+    {
+      title: 'Project 1',
+      description: 'Manage, edit, and sync product information across all your ...',
+      image: projectImage,
+      imageAlt: 'picture of sunny software project',
+    },
+    // Add more projects here
+  ];
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.text}>
+        <h2>What we provide you?</h2>
+        <p>
+          Our mission is to become an extension
+          of your team so we can help your business
+          grow — all while costing you less than a
+          single full-time designer.
+        </p>
+      </div>
+      <div className={styles.portfolioCardsContainer}>
+        {projectsList.map((project, index) => (
+          <PortfolioCard
+            key={index}
+            title={project.title}
+            description={project.description}
+            image={project.image}
+            imageAlt={project.imageAlt}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
 
 export default FullPortfolioList;


### PR DESCRIPTION

Upon reviewing the 'FullPortfolioList' module, I recognized the repetition of portfolio card structures and styling. To enhance maintainability and encourage DRY principles, I propose refactoring the repeated blocks into a new, reusable component, 'PortfolioCard'. This will simplify future updates and adjustments to styling or structure across all instances of portfolio cards, improving the codebase quality and scalability.

By creating this 'PortfolioCard' component, we encapsulate the HTML structure and related styling within a single, coherent unit. Any style or content changes to the portfolio cards will then only need to be made in one place, reducing the risk of inconsistencies and bugs.
