### PR TITLE
Use React Fragments in AboutUsPage to Prevent Unnecessary Div Wrapping

### DIFF
--- a/src/client/pages/AboutUsPage/AboutUsPage.tsx
+++ b/src/client/pages/AboutUsPage/AboutUsPage.tsx
@@ -13,7 +13,7 @@ import CallToAction from '../../components/CallToAction/CallToAction';
 import styles from './AboutUsPage.scss';
 
 const AboutUsPage: FunctionComponent = () => (
-  <div>
+  <>
     <Helmet>
       <meta charSet="utf-8" />
       <title>About Us-Sunny Software</title>
@@ -29,7 +29,7 @@ const AboutUsPage: FunctionComponent = () => (
     <LocationBanner />
     <OurTeamAndOpenings />
     <CallToAction />
-  </div>
+  </>
 );
 
 export default AboutUsPage;


### PR DESCRIPTION

Refactoring `AboutUsPage` to use `React.Fragment` instead of a `div` to avoid adding extraneous nodes to the DOM. Using a `Fragment` is preferred when no HTML grouping is necessary, and it can potentially lead to slight performance improvements and cleaner HTML structure.
