### PR TITLE
Rename `toggleEditState` to `toggleEditing` to clearly reflect its purpose

### DIFF
--- a/src/client/components/IndividualProjects/IndividualProjects.tsx
+++ b/src/client/components/IndividualProjects/IndividualProjects.tsx
@@ -11,7 +11,7 @@ const IndividualProject: FunctionComponent<ClientProject> = (props) => {
 
   const [editing, setEditing] = useState(false);
 
-  const toggleEditState = useCallback(() => {
+  const toggleEditing = useCallback(() => {
     setEditing(!editing);
   }, [editing]);
 
@@ -30,7 +30,7 @@ const IndividualProject: FunctionComponent<ClientProject> = (props) => {
           {active ? 'true' : 'false'}
         </h4>
       </div>
-      <button type="button" onClick={toggleEditState}>More...</button>
+      <button type="button" onClick={toggleEditing}>More...</button>
       {editing && (
         <EditProject
           id={id}


### PR DESCRIPTION
By renaming the `toggleEditState` function to `toggleEditing`, the intention of the function becomes clearer and is more aligned with the state it toggles, which is `editing`. Renaming functions for clarity is a low-risk change that can make the codebase easier to understand and maintain.