### PR TITLE
Refactor 'useIsSmallScreen' Hook to Include Descriptive Name and Enhance Reusability

### DIFF
--- a/src/client/hooks/useIsMobileWidth.ts
+++ b/src/client/hooks/useIsMobileWidth.ts
@@ -1,6 +1,11 @@
 import useInnerWidth from './useInnerWidth';
 
-export default (): boolean => {
+/**
+ * Hook to determine if the screen width is considered small.
+ * @param threshold The maximum width for a screen to be considered small. Defaults to 1024.
+ * @returns A boolean indicating whether the screen is small.
+ */
+export default function useIsSmallScreen(threshold: number = 1024): boolean {
   const width = useInnerWidth();
-  return width < 1024;
+  return width < threshold;
 };


### PR DESCRIPTION

The current anonymous function exported by the module lacks a descriptive name, which can lead to confusion when it is imported and used in various places within the codebase. I have refactored the function to be named `useIsSmallScreen`, giving a clear indication of its purpose to determine if the current screen width corresponds to a small screen size. Additionally, the threshold for small screen size is now a parameter with a default value, allowing for enhanced reusability in different contexts where a different threshold might be preferred.

The change makes the code more readable and maintainable. It also aligns with best practices in terms of code clarity and self-documentation, as a named function is more expressive and easier to understand at a glance compared to an unnamed default export.
