### PR TITLE
Optimize useEffect Dependency in ShowNavBar Component

### DIFF
--- a/src/client/components/ShowNavBar/ShowNavBar.tsx
+++ b/src/client/components/ShowNavBar/ShowNavBar.tsx
@@ -13,11 +13,11 @@ const noNavBarRoutes = new Set([
 
 const ShowNavBar = ({ children }: IProps): React.JSX.Element => {
   const [showNavBar, setShowNavBar] = useState(true);
-  const locationPath = useLocation();
+  const { pathname } = useLocation();
 
   useEffect(() => {
-    setShowNavBar(!noNavBarRoutes.has(locationPath.pathname));
-  }, [locationPath]);
+    setShowNavBar(!noNavBarRoutes.has(pathname));
+  }, [pathname]);
 
   return (
     <div>{showNavBar && children}</div>


### PR DESCRIPTION

Updating the ShowNavBar component to fix excessive re-renders caused by using the location object as a dependency of useEffect. The path is now deconstructed directly from useLocation, ensuring that the effect only re-runs when the pathname changes, not on location object reference changes. This enhances performance, especially in complex apps where location objects may update frequently while the path remains the same.
