### PR TITLE
Refactor 'PortfolioBanner' to use useMemo for Static SVG

### DIFF
--- a/src/client/components/PortfolioPage/PortfolioBanner/PortfolioBanner.tsx
+++ b/src/client/components/PortfolioPage/PortfolioBanner/PortfolioBanner.tsx
@@ -1,10 +1,10 @@
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import Button, { ButtonSize } from '../../Button/Button';
 import styles from './PortfolioBanner.scss';
 
 const PortfolioBanner: FunctionComponent = () => {
-  const backgroundSvg = (
+  const backgroundSvg = useMemo(() => (
     <svg width="979" height="261" viewBox="0 0 979 261" fill="none" xmlns="http://www.w3.org/2000/svg">
       <g opacity="0.6" filter="url(#filter0_f_57_5070)">
         <path d="M238.458 758.661C69.8249 604.081 45.3189 356.37 183.723 205.384C322.126 54.3983 571.029 57.3123 739.662 211.893C908.296 366.473 932.802 614.184 794.398 765.17C601.962 438.939 407.092 913.242 238.458 758.661Z" fill="url(#paint0_linear_57_5070)" />
@@ -21,7 +21,8 @@ const PortfolioBanner: FunctionComponent = () => {
         </linearGradient>
       </defs>
     </svg>
-  );
+  ), []);
+
   return (
     <div className={styles.container}>
       <div className={styles.textAndButton}>


### PR DESCRIPTION
Using useMemo to memoize the static SVG element in the 'PortfolioBanner' component helps in preventing unnecessary re-renderings of the SVG, which does not change between renders. This optimization enhances performance, particularly for SVGs that could be costly to re-render.