### PR TITLE
Refactor 'backgroundSvg' into a Separate React Component for Improved Code Reusability

### DIFF
--- a/src/client/components/CareersPage/CareersBanner/CareersBanner.tsx
+++ b/src/client/components/CareersPage/CareersBanner/CareersBanner.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Button, { ButtonSize } from '../../Button/Button';
 import styles from './CareersBanner.scss';
 
-const backgroundSvg = (
+const BackgroundSvg: FunctionComponent = () => (
   <svg width="979" height="261" viewBox="0 0 979 261" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g opacity="0.6" filter="url(#filter0_f_57_5070)">
       <path d="M238.458 758.661C69.8249 604.081 45.3189 356.37 183.723 205.384C322.126 54.3983 571.029 57.3123 739.662 211.893C908.296 366.473 932.802 614.184 794.398 765.17C601.962 438.939 407.092 913.242 238.458 758.661Z" fill="url(#paint0_linear_57_5070)" />
@@ -35,7 +35,7 @@ const CareersBanner: FunctionComponent = () => (
         Join our team
       </Button>
     </div>
-    {backgroundSvg}
+    <BackgroundSvg />
   </div>
 );
 


### PR DESCRIPTION

Breaking out 'backgroundSvg' from the `CareersBanner` component improves readability and reusability. This commit extracts the inline SVG into its own stateless functional component, simplifying the `CareersBanner` component's structure and allowing the SVG to be potentially reused in other parts of the application without duplicating code.
