### PR TITLE
Refactor MethodologyPage Component to Include Helmet Initialization as a Standalone Functional Component

### DIFF
--- a/src/client/pages/MethodologyPage/MethodologyPage.tsx
+++ b/src/client/pages/MethodologyPage/MethodologyPage.tsx
@@ -6,17 +6,21 @@ import MethodologyFullList from '../../components/MethodologyPage/MethodologyFul
 import MethodologyBenefits from '../../components/MethodologyPage/MethodologyBenefits/MethodologyBenefits';
 import MethodologyNeedHelp from '../../components/MethodologyPage/MethodologyNeedHelp/MethodologyNeedHelp';
 
+const MethodologyHelmet: FunctionComponent = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Methodology-Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/methodology" />
+    <meta
+      name="description"
+      content="The methodology of Sunny Software LLC"
+    />
+  </Helmet>
+);
+
 const MethodologyPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Methodology-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/methodology" />
-      <meta
-        name="description"
-        content="The methodology of Sunny Software LLC"
-      />
-    </Helmet>
+    <MethodologyHelmet />
     <MethodologyBanner />
     <MethodologyFullList />
     <MethodologyBenefits />


### PR DESCRIPTION

The `MethodologyPage` component includes the setup of the `Helmet` component directly inside the main function. This makes the `MethodologyPage` less focused on its main responsibility and harder to test or reuse. By extracting the helmet setup into its own component, we can improve the separation of concerns and make the `MethodologyPage` cleaner.

To achieve this, I created a new functional component named `MethodologyHelmet`. This component is responsible for initializing the helmet with the relevant meta tags for the `MethodologyPage`. The `MethodologyPage` now simply uses this new `MethodologyHelmet` component, resulting in a more concise and maintainable codebase.

This refactor does not add any new functionality but improves readability and maintainability, which is crucial for the long-term health of the codebase.
