### PR TITLE
Rename 'Testimonials-Sunny Software' page title to 'Careers at Sunny Software' for clarity

### DIFF
--- a/src/client/pages/CareersPage/CareersPage.tsx
+++ b/src/client/pages/CareersPage/CareersPage.tsx
@@ -10,11 +10,11 @@ const CareersPage: FunctionComponent = () => (
   <div>
     <Helmet>
       <meta charSet="utf-8" />
-      <title>Testimonials-Sunny Software</title>
+      <title>Careers at Sunny Software</title>
       <link rel="canonical" href="https://sunnysoftware.dev/team" />
       <meta
         name="description"
-        content="Testimonails describing the good work of Sunny Software"
+        content="Explore career opportunities and open positions at Sunny Software. Join our team and bring your own ideas to life!"
       />
     </Helmet>
     <CareersBanner />


### PR DESCRIPTION

The title within the CareerPage's Helmet component currently says 'Testimonials-Sunny Software', which can be confusing since the page is about careers, not just testimonials. The title should be renamed to 'Careers at Sunny Software' to better reflect the content of the page and improve SEO.

Updating the title also aligns with best practices for clarity and SEO optimization. When people search for career opportunities, they are more likely to use the term "Careers" rather than "Testimonials," so this change should help potential applicants find the page more easily.
