### PR TITLE
Rename 'meta' description content for accuracy in 'CareersPage' component

### DIFF
--- a/src/client/pages/CareersPage/CareersPage.tsx
+++ b/src/client/pages/CareersPage/CareersPage.tsx
@@ -10,11 +10,11 @@ const CareersPage: FunctionComponent = () => (
   <div>
     <Helmet>
       <meta charSet="utf-8" />
-      <title>Testimonials-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/team" />
+      <title>Careers at Sunny Software</title>
+      <link rel="canonical" href="https://sunnysoftware.dev/careers" />
       <meta
         name="description"
-        content="Testimonails describing the good work of Sunny Software"
+        content="Explore current job openings and our culture to start your career with Sunny Software. Join a team that values innovation and collaboration."
       />
     </Helmet>
     <CareersBanner />


### PR DESCRIPTION

The meta description in the 'CareersPage' component inaccurately references "Testimonails" and does not accurately describe the career-related content of the page. The description has been adjusted to better align with the career aspect of the page, providing a more relevant and concise summary for search engine optimization (SEO) purposes.

This change enhances the relevance of the page for search engine users looking for career information, potentially improving the page's SEO performance and click-through rate from searches.
