### PR TITLE
Updated import declarations in 'logger' module for clarity and single-responsibility

### DIFF
--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,5 +1,5 @@
-import logger, { LogLevel } from 'eleventh';
+import defaultLogger, { LogLevel } from 'eleventh';
 
-logger.setLogLevel(LogLevel.debug);
+defaultLogger.setLogLevel(LogLevel.debug);
 
-export default logger;
+export default defaultLogger;


### PR DESCRIPTION

The provided TypeScript module 'logger' was refactored to separate concerns and improve import clarity. 
By renaming the default import to 'defaultLogger', it becomes clear within the context of the codebase 
that this is a logger instance with predefined configurations. This change ensures that future code within 
the module that may require additional logger instances or utilities from 'eleventh' will be clearer and more 
readable for developers.
