### PR TITLE
Optimize `useNavigate` to Prevent Unnecessary Redirects in `ForgotPassword` Component

### DIFF
--- a/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
+++ b/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { FunctionComponent, ChangeEvent, FormEvent } from 'react';
 import { useSelector } from 'react-redux';
@@ -15,6 +15,15 @@ const ForgotPassword: FunctionComponent = () => {
   const [showSuccessPopup, setShowSuccessPopup] = useState(false);
   const [showErrorPopup, setShowErrorPopup] = useState(false);
 
+  const navigate = useNavigate();
+  const loggedIn = useSelector(getLoggedIn);
+
+  useEffect(() => {
+    if (loggedIn) {
+      navigate('/');
+    }
+  }, [loggedIn, navigate]);
+
   const showSuccessPopupFunction = useCallback(() => {
     setShowSuccessPopup(!showSuccessPopup);
   }, [showSuccessPopup]);
@@ -22,12 +31,6 @@ const ForgotPassword: FunctionComponent = () => {
   const showErrorPopupFunction = useCallback(() => {
     setShowErrorPopup(!showErrorPopup);
   }, [showErrorPopup]);
-
-  const navigate = useNavigate();
-  const loggedIn = useSelector(getLoggedIn);
-  if (loggedIn) {
-    navigate('/');
-  }
 
   const handleEmailChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -92,7 +95,7 @@ const ForgotPassword: FunctionComponent = () => {
       )}
       <form
         className={styles.forgotPassword}
-        onClick={handleSubmit}
+        onSubmit={handleSubmit}
       >
         <div>
           <label className={styles.boxAndLabel}>
@@ -106,11 +109,10 @@ const ForgotPassword: FunctionComponent = () => {
             />
           </label>
         </div>
-        <div />
         <div className={styles.buttons}>
           <Button
-            size={ButtonSize.Large}
-            type={ButtonType.Submit}
+            size={ButtonSize.large}
+            type={ButtonType.submit}
           >
             Reset password
           </Button>


### PR DESCRIPTION

The `ForgotPassword` React component currently checks for `loggedIn` status and performs a redirect if the user is already logged in. However, this check is performed on each re-render which can lead to unnecessary redirects and potentially disallow users from using the forgot password functionality if the state changes unexpectedly. The suggested refactor wraps the `loggedIn` check and navigation into a `useEffect` to ensure it only runs when the `loggedIn` status changes.

This approach minimizes unnecessary re-renders and side-effects, providing a more predictable user experience and potentially enhancing performance.
