### PR TITLE
Optimize 'handleActiveChange' to Directly Update State in EditProject

### DIFF
--- a/src/client/components/EditProject/EditProject.tsx
+++ b/src/client/components/EditProject/EditProject.tsx
@@ -24,15 +24,14 @@ const EditProject: FunctionComponent<ClientProject> = (props) => {
     [setNewTitle],
   );
 
-  const handleDescriptionChange
-   = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
-     setNewDescription(e.target.value);
-     setSubmitted(false);
-   }, [setNewDescription],);
+  const handleDescriptionChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    setNewDescription(e.target.value);
+    setSubmitted(false);
+  }, [setNewDescription],);
 
   const handleActiveChange = useCallback((): void => {
-    setNewActive(!active);
-  }, [active],);
+    setNewActive(currentActive => !currentActive);
+  }, [setNewActive],);
 
   // Update Project information
   const handleSubmit = useCallback(async(e: SyntheticEvent) => {
@@ -159,7 +158,6 @@ const EditProject: FunctionComponent<ClientProject> = (props) => {
             type="radio" name="activeRadioGroup" id="inactiveRadio"
             value="false" onChange={handleActiveChange}
             checked={!newActive}
-
           />
 
         </div>


### PR DESCRIPTION

Current implementation of 'handleActiveChange' flips the 'active' prop instead of the newActive state. Refactoring this function to use current state ensures correct toggle behavior even if props somehow change between renders.

The function's dependency on props can potentially lead to bugs: This edit makes 'handleActiveChange' only depend on the current component state, which is the source of truth for the form. This improves reliability and correctness within the component lifecycle.
