### PR TITLE
Refactor JobOpeningCard to Utilize useMemo for Derived State

### DIFF
--- a/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
+++ b/src/client/components/CareersPage/Openings/JobOpeningCard/JobOpeningCard.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import Button, { ButtonSize } from '../../../Button/Button';
 import useIsMobileWidth from '../../../../hooks/useIsMobileWidth';
 import styles from './JobOpeningCard.scss';
@@ -18,7 +18,10 @@ const JobOpeningCard: FunctionComponent<JobOpeningCardProps> = ({
   url,
 }) => {
   const isMobileWidth = useIsMobileWidth();
-  const buttonSize = isMobileWidth ? ButtonSize.Small : ButtonSize.Medium;
+  const buttonSize = useMemo(() => {
+    return isMobileWidth ? ButtonSize.Small : ButtonSize.Medium;
+  }, [isMobileWidth]);
+
   return (
     <div className={styles.container}>
       <div className={styles.text}>


### PR DESCRIPTION

To ensure greater performance and avoid unnecessary recalculations, the `JobOpeningCard` component's button size determination has been wrapped in a `useMemo` hook. In React, this pattern is recommended for derived state values that depend on props or other state values, to prevent them from being recalculated on every render when their dependencies have not changed.

This update ensures that the `buttonSize` variable is only recalculated when `isMobileWidth` changes, rather than on every render, which can improve the component's performance, especially in complex applications or when the component is rendered frequently.
