### PR TITLE
Improve type safety in logger default export

### DIFF
--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,5 +1,7 @@
-import logger, { LogLevel } from 'eleventh';
+import logger, { Logger, LogLevel } from 'eleventh';
 
 logger.setLogLevel(LogLevel.debug);
 
-export default logger;
+const typedLogger: Logger = logger;
+
+export default typedLogger;


### PR DESCRIPTION

By providing an explicit typing for the default export, we improve type safety and clarify the intended usage of the exported logger. Users of the module can immediately see the logger's interface rather than relying on implicit type inference or having to inspect the source or typings of the 'eleventh' library. This enhancement ensures that any consumer of this module benefits from TypeScript's type system without any ambiguity regarding the logger's API.
