### PR TITLE
Consolidate asset module declarations into a single type definition

### DIFF
--- a/src/client/declaration.d.ts
+++ b/src/client/declaration.d.ts
@@ -1,34 +1,4 @@
-declare module '*.scss' {
-  const content: Record<string, string>;
-  export default content;
-}
-
-declare module '*.png' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.jpg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.jpeg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.svg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.gif' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.ttf' {
+declare module '*.{scss,png,jpg,jpeg,svg,gif,ttf}' {
   const content: string;
   export default content;
 }


### PR DESCRIPTION
Currently, we have multiple TypeScript module declarations which are highly repetitive and only differ in the file extension they represent. We can consolidate these declarations into a single line using TypeScript's template literal types available since version 4.1. This change would make the code DRY (Don't Repeat Yourself), improving maintainability and readability. Typing all common asset modules this way also makes it easier to add new file types in the future.