### PR TITLE
Extract FAQBanner Text Content as a Component Prop

### DIFF
--- a/src/client/components/FAQPage/FAQBanner/FAQBanner.tsx
+++ b/src/client/components/FAQPage/FAQBanner/FAQBanner.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import styles from './FAQBanner.scss';
 
-const FAQBanner: React.FunctionComponent = () => (
+interface FAQBannerProps {
+  title?: string;
+  description?: string;
+}
+
+const defaultTitle = 'FAQ';
+const defaultDescription = 'Step into the future with our cutting-edge technology solutions tailored for your business needs.';
+
+const FAQBanner: React.FunctionComponent<FAQBannerProps> = ({ title = defaultTitle, description = defaultDescription }) => (
   <div className={styles.container}>
     <div className={styles.text}>
-      <h1>FAQ</h1>
-      <p>
-        Step into the future with our cutting-edge
-        technology solutions tailored for your business
-        needs.
-      </p>
+      <h1>{title}</h1>
+      <p>{description}</p>
     </div>
   </div>
 );


### PR DESCRIPTION

This change improves the `FAQBanner` component by allowing dynamic text content to be passed in as a prop, rather than being hardcoded. This enhances the reusability and flexibility of the component for different use cases or localizations. The updated component now accepts a `title` and `description` prop, and defaults are provided to preserve backward compatibility.

Existing usages of `FAQBanner` will continue to display the same content unless overridden by passing new props.
