### PR TITLE
Rename 'authenticationToken' to 'userToken' for consistency in logout error message

### DIFF
--- a/src/server/api/logout.ts
+++ b/src/server/api/logout.ts
@@ -9,11 +9,11 @@ router.post('/', (req, res) => {
     if (!isObjectRecord(req.cookies)) {
       throw new Error('api/login: req.body is not object');
     }
-    const { authenticationToken } = req.cookies;
-    if (typeof authenticationToken !== 'string') {
+    const { authenticationToken: userToken } = req.cookies;
+    if (typeof userToken !== 'string') {
       throw new Error('api/logout: userToken not type string');
     }
-    const result = await markTokenInactive(authenticationToken);
+    const result = await markTokenInactive(userToken);
 
     res.clearCookie('authenticationToken', { sameSite: 'lax' });
 


### PR DESCRIPTION

The error message for an invalid token type in the logout route mentioned 'userToken' but the actual name of the token in the code is 'authenticationToken'. To avoid confusion and improve consistency, renaming the 'authenticationToken' variable to 'userToken' aligns with the error message. This makes the codebase more intuitive and maintains consistency across error reporting.
