### PR TITLE
Optimized 'AdminPrivateRoute' with React.Memo for Performance Enhancement

### DIFF
--- a/src/client/components/PrivateRoutes/AdminPrivateRoute.tsx
+++ b/src/client/components/PrivateRoutes/AdminPrivateRoute.tsx
@@ -7,7 +7,7 @@ interface IProps {
   children: React.JSX.Element;
 }
 
-const AdminPrivateRoute = ({ children }: IProps): React.JSX.Element => {
+const AdminPrivateRouteBase = ({ children }: IProps): React.JSX.Element => {
   const isAdmin = useSelector(getIsAdmin);
   if (!isAdmin) {
     return <Navigate to="/login" />;
@@ -15,5 +15,7 @@ const AdminPrivateRoute = ({ children }: IProps): React.JSX.Element => {
 
   return children;
 };
+
+const AdminPrivateRoute = React.memo(AdminPrivateRouteBase);
 
 export default AdminPrivateRoute;


### PR DESCRIPTION

To prevent unnecessary re-renders of `AdminPrivateRoute` which can occur when the parent component re-renders, I have wrapped the component with `React.memo`. This is especially useful in this case since `AdminPrivateRoute` doesn't have any props that affect its rendering besides `children`. As it's likely this component could be used frequently across the application, optimizing it to only re-render when necessary can have a performance benefit by reducing the workload on React's reconciliation algorithm.
