### PR TITLE
Refactor LoginPage to use useEffect for Redirect Logic

### DIFF
--- a/src/client/pages/LoginPage/LoginPage.tsx
+++ b/src/client/pages/LoginPage/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import type { FunctionComponent } from 'react';
@@ -12,9 +12,12 @@ import styles from './LoginPage.scss';
 const LoginPage: FunctionComponent = () => {
   const navigate = useNavigate();
   const loggedIn = useSelector(getLoggedIn);
-  if (loggedIn) {
-    navigate('/');
-  }
+
+  useEffect(() => {
+    if (loggedIn) {
+      navigate('/');
+    }
+  }, [loggedIn, navigate]);
 
   return (
     <div className={styles.pageContainer}>


### PR DESCRIPTION

Refactoring the redirect logic in the LoginPage component by moving side effects into the useEffect hook to ensure redirection only occurs after the component is mounted. This prevents potential navigation actions during render, following good practice for handling side effects in functional components.

This change is valuable as it reinforces correct usage of hooks in the functional component, aligning with React's expected patterns for handling side effects and avoiding any possible issues that could arise from redirecting during rendering.
