### PR TITLE
Refactor 'reducer' to 'rootReducer' for Clarity in Export

### DIFF
--- a/src/client/redux/slices/index.ts
+++ b/src/client/redux/slices/index.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import account from './account';
 
-export const reducer = combineReducers({
+export const rootReducer = combineReducers({
   account,
 });


### PR DESCRIPTION
After reviewing the provided TypeScript file which handles the combination of reducers for a Redux store, I suggest a small, yet clarifying refactor. The current export name 'reducer' is somewhat generic and might not clearly convey its purpose, especially when imported elsewhere in a larger application. By renaming 'reducer' to 'rootReducer', we provide immediate context to the developers that this is the main reducer combined from other reducers using combineReducers from Redux. This improvement enhances the readability and maintainability of the codebase by being explicit about the role of the exported reducer.