### PR TITLE
Rename 'FunctionComponent' Import to 'FC' for Consistency and Clean Code in ResourcesPage

### DIFF
--- a/src/client/pages/ResourcesPage/ResourcesPage.tsx
+++ b/src/client/pages/ResourcesPage/ResourcesPage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import type { FunctionComponent } from 'react';
+import type { FC } from 'react';
 import { Helmet } from 'react-helmet';
 import ResourcesBanner from '../../components/ResourcesPage/ResourcesBanner/ResourcesBanner';
 import ResourcesPanels from '../../components/ResourcesPage/ResourcesPanels/ResourcesPanels';
 
-const ResourcesPage: FunctionComponent = () => (
+const ResourcesPage: FC = () => (
   <div>
     <Helmet>
       <meta charSet="utf-8" />


### PR DESCRIPTION

To achieve a more consistent and concise codebase, the 'FunctionComponent' type import from React has been changed to 'FC'. This refactor does not impact functionality but aligns with common conventions and reduces verbosity without sacrificing readability.
