### PR TITLE
Refactor Background SVG into a Separate React Component to Clean Up OurTeamAndOpenings Component

### DIFF
--- a/src/client/components/OurTeamAndOpenings/OurTeamAndOpenings.tsx
+++ b/src/client/components/OurTeamAndOpenings/OurTeamAndOpenings.tsx
@@ -7,25 +7,26 @@ import imageAt2 from './imageAt2.jpg';
 import imageAt5 from './imageAt5.jpg';
 import imageAt830 from './ImageAt830.jpg';
 
+const BackgroundSvg: FunctionComponent = () => (
+  <svg width="500" height="500" viewBox="0 0 405 416" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#filter0_f_239_2929)">
+      <path d="M98.3758 151.273C129.693 96.8178 199.207 78.05 253.638 109.354C308.069 140.658 326.806 210.179 295.489 264.634C264.171 319.089 194.658 337.857 140.227 306.553C219.177 237.192 67.0583 205.728 98.3758 151.273Z" fill="url(#paint0_linear_239_2929)" />
+    </g>
+    <defs>
+      <filter id="filter0_f_239_2929" x="0.0612488" y="0.20401" width="404.595" height="415.499" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="47" result="effect1_foregroundBlur_239_2929" />
+      </filter>
+      <linearGradient id="paint0_linear_239_2929" x1="238.783" y1="363.234" x2="154.756" y2="52.0086" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#F3AA1F" />
+        <stop offset="1" stopColor="#FED323" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+
 const OurTeamAndOpenings: FunctionComponent = () => {
-  const backgroundSvg = (
-    <svg width="500" height="500" viewBox="0 0 405 416" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <g filter="url(#filter0_f_239_2929)">
-        <path d="M98.3758 151.273C129.693 96.8178 199.207 78.05 253.638 109.354C308.069 140.658 326.806 210.179 295.489 264.634C264.171 319.089 194.658 337.857 140.227 306.553C219.177 237.192 67.0583 205.728 98.3758 151.273Z" fill="url(#paint0_linear_239_2929)" />
-      </g>
-      <defs>
-        <filter id="filter0_f_239_2929" x="0.0612488" y="0.20401" width="404.595" height="415.499" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feGaussianBlur stdDeviation="47" result="effect1_foregroundBlur_239_2929" />
-        </filter>
-        <linearGradient id="paint0_linear_239_2929" x1="238.783" y1="363.234" x2="154.756" y2="52.0086" gradientUnits="userSpaceOnUse">
-          <stop stopColor="#F3AA1F" />
-          <stop offset="1" stopColor="#FED323" />
-        </linearGradient>
-      </defs>
-    </svg>
-  );
   return (
     <div className={styles.containerOurTeamAndOpenings}>
       <div className={styles.teamCircleImages}>
@@ -33,7 +34,7 @@ const OurTeamAndOpenings: FunctionComponent = () => {
         <img className={styles.imageTwo} src={imageAt2} alt="sunny software employee" />
         <img className={styles.imageThree} src={imageAt5} alt="sunny software employee" />
         <img className={styles.imageFour} src={imageAt830} alt="sunny software employee" />
-        {backgroundSvg}
+        <BackgroundSvg />
       </div>
       <div className={styles.textAndOpenenings}>
         <div className={styles.teamAndOpeningsText}>


### PR DESCRIPTION

To enhance the readability and maintainability of the OurTeamAndOpenings component, this refactor extracts the inline SVG code into its own React Functional Component named BackgroundSvg. This simplification results in a cleaner OurTeamAndOpenings component, allowing for easier understanding and potential reusability of the SVG component elsewhere in the codebase if needed.
