### PR TITLE
Reduce Redundancy in Asset Type Declarations by Introducing Generic Module Definition

### DIFF
--- a/src/client/declaration.d.ts
+++ b/src/client/declaration.d.ts
@@ -1,34 +1,4 @@
-declare module '*.scss' {
-  const content: Record<string, string>;
-  export default content;
-}
-
-declare module '*.png' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.jpg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.jpeg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.svg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.gif' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.ttf' {
+declare module '*.{scss,png,jpg,jpeg,svg,gif,ttf}' {
   const content: string;
   export default content;
 }


### PR DESCRIPTION

The current TypeScript file contains multiple module declarations for different asset file types. This includes .scss, .png, .jpg, .jpeg, .svg, .gif, and .ttf files. Each declaration essentially has the same structure, differing only by the file extension in the module name.

To improve the maintainability and reduce redundancy in our type declarations, this pull request introduces a single generic module declaration using a wildcard pattern for all asset file types. This approach leverages TypeScript's pattern matching for module names, allowing us to define a single type for all specified file extensions, thereby simplifying the file and making it easier to extend to new file types in the future if necessary.

By using this refactor, we'll have a cleaner, more maintainable, and easily extendable set of type declarations for asset modules.
