### PR TITLE
Rename 'ClientPortalPage' to 'ClientPortal' for Consistency with Other Pages

### DIFF
--- a/src/client/pages/ClientPortalPage/ClientPortalPage.tsx
+++ b/src/client/pages/ClientPortalPage/ClientPortalPage.tsx
@@ -3,7 +3,7 @@ import type { FunctionComponent } from 'react';
 import { Helmet } from 'react-helmet';
 import ResetPassword from '../../components/ResetPassword/ResetPassword';
 
-const ClientPortalPage: FunctionComponent = () => (
+const ClientPortal: FunctionComponent = () => (
   <div>
     <Helmet>
       <meta charSet="utf-8" />
@@ -17,4 +17,4 @@ const ClientPortalPage: FunctionComponent = () => (
   </div>
 );
 
-export default ClientPortalPage;
+export default ClientPortal;


### PR DESCRIPTION

In an effort to maintain consistency within our project's naming conventions, I propose renaming the 'ClientPortalPage' to simply 'ClientPortal'. This aligns with the naming of other components that represent pages within our application and removes the redundant 'Page' suffix which is not needed given the context.

This change not only improves the readability of our component hierarchy but also follows best practices where the component's name should ideally reflect its purpose without superfluous words. By making our component names concise and descriptive, we optimize the developer experience for our team.
