### PR TITLE
Rename 'MangageProjects' import to 'ManageProjects' for consistency and accuracy

### DIFF
--- a/src/client/pages/AdminPortal/AdminPortalPage.tsx
+++ b/src/client/pages/AdminPortal/AdminPortalPage.tsx
@@ -6,7 +6,7 @@ import EmployeeWorkCalendars from '../../components/EmployeeWorkCalendars/Employ
 import RegistrationForm from '../../components/RegistrationForm/RegistrationForm';
 import ManageUsers from '../../components/ManageUsers/ManageUsers';
 import ResetPassword from '../../components/ResetPassword/ResetPassword';
-import ManageProjects from '../../components/MangageProjects/ManageProjects';
+import ManageProjects from '../../components/ManageProjects/ManageProjects';
 
 const AdminPortalPage: FunctionComponent = () => (
   <div>


### PR DESCRIPTION

While reviewing the import section of the code, I spotted a typographical error in the `ManageProjects` component import. The incorrect spelling "MangageProjects" could lead to confusion and potential import errors. Correcting it to "ManageProjects" maintains consistency with the naming convention and prevents any misunderstandings due to typos. This change enhances the overall readability of the code and ensures correct component references.
