### PR TITLE
Improve state management in 'Navbar' for resize event handling

### DIFF
--- a/src/client/components/NavBar/NavBar.tsx
+++ b/src/client/components/NavBar/NavBar.tsx
@@ -26,7 +26,7 @@ const Navbar: FunctionComponent = () => {
     if (!isMobileWidth) {
       setHamburgerOpen(false);
     }
-  }, [hamburgerOpen, isMobileWidth]);
+  }, [isMobileWidth]);
 
   const handleSubmit = useCallback(async(): Promise<void> => {
     if (loggedIn) {


### PR DESCRIPTION

Currently, the 'Navbar' component uses both 'hamburgerOpen' and 'isMobileWidth' states within the resize effect to handle the mobile menu visibility. The downside of this approach is that it introduces an unnecessary dependency on 'hamburgerOpen' state which can potentially lead to redundant effect executions. Since the goal is simply to close the hamburger menu when transitioning to a non-mobile width, we can remove 'hamburgerOpen' from the dependency array, enhancing the performance by avoiding the effect to rerun when the hamburger state changes but the width does not.

With this change, the resize effect will now only re-run when 'isMobileWidth' changes, which is directly related to the browser resize and is the intended behavior to manage the mobile menu visibility. This makes the component more efficient and the intention of the effect clearer to other developers.
