### PR TITLE
Rename 'handleSubmit' to 'handleForgotPassword' for clarity in ForgotPassword Component

### DIFF
--- a/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
+++ b/src/client/components/LoginPage/ForgotPassword/ForgotPassword.tsx
@@ -25,6 +25,7 @@ const ForgotPassword: FunctionComponent = () => {
 
   const navigate = useNavigate();
   const loggedIn = useSelector(getLoggedIn);
+  
   if (loggedIn) {
     navigate('/');
   }
@@ -36,7 +37,7 @@ const ForgotPassword: FunctionComponent = () => {
     [setEmail],
   );
 
-  const handleSubmit = useCallback(async(e: FormEvent<HTMLFormElement>) => {
+  const handleForgotPassword = useCallback(async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
       const response = await fetch('/api/forgotPassword', {
@@ -92,7 +93,7 @@ const ForgotPassword: FunctionComponent = () => {
       )}
       <form
         className={styles.forgotPassword}
-        onClick={handleSubmit}
+        onSubmit={handleForgotPassword}
       >
         <div>
           <label className={styles.boxAndLabel}>
@@ -120,4 +121,5 @@ const ForgotPassword: FunctionComponent = () => {
     </div>
   );
 };
+
 export default ForgotPassword;


### PR DESCRIPTION

When reviewing the current implementation of the ForgotPassword component, I observed that the name of the form submission handler function `handleSubmit` is somewhat generic. In a component context where multiple forms could hypothetically exist, specifically naming the behavior of the function can provide clearer intent and improve maintainability.

This refactoring is a step toward more expressive and self-documenting code, ensuring clarity for current and future developers who work on this component. The new function name `handleForgotPassword` explicitly communicates the specific action of the form, which is to handle a user's request to reset their password.
