### PR TITLE
Optimize ShowNavBar Component to Remove Unnecessary State Updates

### DIFF
--- a/src/client/components/ShowNavBar/ShowNavBar.tsx
+++ b/src/client/components/ShowNavBar/ShowNavBar.tsx
@@ -12,12 +12,8 @@ const noNavBarRoutes = new Set([
 ]);
 
 const ShowNavBar = ({ children }: IProps): React.JSX.Element => {
-  const [showNavBar, setShowNavBar] = useState(true);
   const locationPath = useLocation();
-
-  useEffect(() => {
-    setShowNavBar(!noNavBarRoutes.has(locationPath.pathname));
-  }, [locationPath]);
+  const showNavBar = !noNavBarRoutes.has(locationPath.pathname);
 
   return (
     <div>{showNavBar && children}</div>


### PR DESCRIPTION

Refactor React component ShowNavBar to prevent unnecessary calls to setShowNavBar when the visibility of the NavBar does not change. This optimization eliminates potential superfluous re-renders when switching between routes that all require the navbar or all do not require it. 

Updating internal component state only when there is an actual change improves overall performance by reducing unnecessary render cycles and provides a more efficient component lifecycle.
