### PR TITLE
Rename '__INITIAL_STATE__' Global Window Property to 'initialReduxState' for Reduced Confusion and Improved Consistency

### DIFF
--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -6,12 +6,12 @@ export type State = ReturnType<typeof reducer>;
 declare global {
   interface Window {
     // eslint-disable-next-line id-match
-    __INITIAL_STATE__: State;
+    initialReduxState: State;
   }
 }
 
-// eslint-disable-next-line no-underscore-dangle
-const preloadedState = window.__INITIAL_STATE__;
+// Let's adhere to standard JS practices by avoiding variable names with double underscores
+const preloadedState = window.initialReduxState;
 
 const store = configureStore({
   reducer,


### PR DESCRIPTION

The use of '__INITIAL_STATE__' as a global property on the window object is non-standard and can lead to confusion, as double underscores are commonly used in other contexts to denote private attributes. To enhance readability and maintain consistency with idiomatic JavaScript and TypeScript practices, I suggest renaming '__INITIAL_STATE__' to 'initialReduxState'. This change will make the purpose of the variable more clear to developers and avoids the potential for misunderstanding the naming convention.
