### PR TITLE
Refactored router setup to dynamically import and register routes

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -1,28 +1,25 @@
 import { Router as createRouter } from 'express';
-import login from './login';
-import logout from './logout';
-import register from './register';
-import authenticate from './authenticate';
-import workLogs from './workLogs';
-import weeklyWorkLogs from './weeklyWorkLogs';
-import contacts from './contacts';
-import timesheets from './timesheets';
-import users from './users';
-import projects from './projects';
-import forgotPassword from './forgotPassword';
 
 const router = createRouter();
 
-router.use('/login', login);
-router.use('/logout', logout);
-router.use('/register', register);
-router.use('/authenticate', authenticate);
-router.use('/workLogs', workLogs);
-router.use('/weeklyWorkLogs', weeklyWorkLogs);
-router.use('/contacts', contacts);
-router.use('/timesheets', timesheets);
-router.use('/users', users);
-router.use('/projects', projects);
-router.use('/forgotPassword', forgotPassword);
+const routes = {
+  '/login': () => import('./login'),
+  '/logout': () => import('./logout'),
+  '/register': () => import('./register'),
+  '/authenticate': () => import('./authenticate'),
+  '/workLogs': () => import('./workLogs'),
+  '/weeklyWorkLogs': () => import('./weeklyWorkLogs'),
+  '/contacts': () => import('./contacts'),
+  '/timesheets': () => import('./timesheets'),
+  '/users': () => import('./users'),
+  '/projects': () => import('./projects'),
+  '/forgotPassword': () => import('./forgotPassword'),
+};
+
+Object.entries(routes).forEach(([path, routeModule]) => {
+  routeModule().then(module => {
+    router.use(path, module.default);
+  });
+});
 
 export default router;


### PR DESCRIPTION

To increase maintainability, the router setup has been refactored to dynamically import and register routes. This reduces the need for manual addition or removal of `router.use()` calls when routes are added or removed. A mapping structure `routes` has been included to associate route paths with their respective modules. This change streamlines the router setup code and adheres to the DRY (Don't Repeat Yourself) principle.
