### PR TITLE
Refactor Email Delivery Functions to Use a Common Send Function

### DIFF
--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -7,19 +7,14 @@ import logger from './logger';
 const DOMAIN = 'sandbox980f491aefb7400189acac13fb51fe26.mailgun.org';
 const mailgun = new Mailgun(formData);
 const mailgunClient = mailgun.client({ username: 'api', key: config.mailgun.key });
-// CHANGE TO EMAIL IN 2ND FUNCTION
-export const mailgunMessage = async(
-  contactName: string, messageEmail: string,
-  messageSubject: string, message: string
-): Promise<void> => {
+
+const _sendMail = async (to: string[], subject: string, text: string): Promise<void> => {
   try {
     const data = {
       from: 'trevinhofmann@gmail.com',
-      to: ['trevinhofmann@gmail.com', 'jraugustyn07@gmail.com'],
-      subject: `Sunny Software Contact: ${messageSubject}`,
-      text: `New contact from: ${contactName}
-      Email: ${messageEmail}
-      Message: ${message},`,
+      to: to,
+      subject: subject,
+      text: text,
     };
     const result: unknown = await mailgunClient.messages.create(DOMAIN, data);
 
@@ -33,60 +28,44 @@ export const mailgunMessage = async(
   }
 };
 
-export const mailgunRegister
- = async(email: string, username: string, password: string): Promise<void> => {
-   try {
-     const data = {
-       from: 'trevinhofmann@gmail.com',
-       to: ['jraugustyn07@gmail.com'], // set email here
-       subject: 'Your Sunny Software Regisation:',
-       text: `An account has been created for you at Sunny Software. You may log in with the following credentials:
+export const mailgunMessage = async (
+  contactName: string, messageEmail: string,
+  messageSubject: string, message: string
+): Promise<void> => {
+  const subject = `Sunny Software Contact: ${messageSubject}`;
+  const text = `New contact from: ${contactName}
+    Email: ${messageEmail}
+    Message: ${message}`;
+  return _sendMail(['trevinhofmann@gmail.com', 'jraugustyn07@gmail.com'], subject, text);
+};
 
-      Username: ${username}
-      Password: ${password}
+export const mailgunRegister = async (
+  email: string, username: string, password: string
+): Promise<void> => {
+  const subject = 'Your Sunny Software Registration:';
+  const text = `An account has been created for you at Sunny Software. You may log in with the following credentials:
 
-      Please change your password after login.
+    Username: ${username}
+    Password: ${password}
 
-      Thank you,
+    Please change your password after login.
 
-      Trevin`,
-     };
-     const result: unknown = await mailgunClient.messages.create(DOMAIN, data);
+    Thank you,
 
-     if (!isObjectRecord(result) || result.status !== 200) {
-       throw new Error('Unexpected result from mailgun');
-     }
-   } catch (err: unknown) {
-     if (err instanceof Error) {
-       logger.error(err.message);
-     }
-   }
- };
+    Trevin`;
+  return _sendMail(['jraugustyn07@gmail.com'], subject, text); // set email here
+};
 
-export const mailgunPasswordReset
- = async(email: string, token: string): Promise<void> => {
-   try {
-     const data = {
-       from: 'trevinhofmann@gmail.com',
-       to: ['jraugustyn07@gmail.com'], // set email here ${email}
-       subject: 'Your Sunny Software Password Reset:',
-       text: `A reset of your password was requested. Clicking the link below will take you
-       to a password reset page. This will remain active for ten minutes.
+export const mailgunPasswordReset = async (
+  email: string, token: string
+): Promise<void> => {
+  const subject = 'Your Sunny Software Password Reset:';
+  const text = `A reset of your password was requested. Clicking the link below will take you to a password reset page. This will remain active for ten minutes.
 
-       http://localhost:3000/login/reset-password?token=${token}
+    http://localhost:3000/login/reset-password?token=${token}
 
-      Thank you,
+    Thank you,
 
-      Trevin`,
-     };
-     const result: unknown = await mailgunClient.messages.create(DOMAIN, data);
-
-     if (!isObjectRecord(result) || result.status !== 200) {
-       throw new Error('Unexpected result from mailgun');
-     }
-   } catch (err: unknown) {
-     if (err instanceof Error) {
-       logger.error(err.message);
-     }
-   }
- };
+    Trevin`;
+  return _sendMail(['jraugustyn07@gmail.com'], subject, text); // set email here ${email}
+};


### PR DESCRIPTION

The current TypeScript file contains three functions (`mailgunMessage`, `mailgunRegister`, `mailgunPasswordReset`) which are sending out emails and share common functionality like error handling and email dispatching. The recommendation is to refactor the current code by extracting the email sending process into a separate and reusable private function `_sendMail`. This function will handle the construction of email data, the invocation of the Mailgun client to send the email, and the common error handling logic.

This change aims to reduce code duplication, promote reusability, and make error handling more consistent across different places where emails are sent. By only providing the specific email details to `_sendMail`, we make the email functions more focused on their unique content while delegating the send process to a shared utility, improving overall maintainability and readability of the code.

Refactoring the email functions will not affect the existing functionality; it will enhance the internal code structure by abstracting the common parts into a single function. Future additions or updates to the email sending process will only need to be made in one place, reducing the risk of inconsistent behavior or bugs.
