### PR TITLE
Improve type definition for 'AccountState' to enforce non-nullable properties upon login

### DIFF
--- a/src/client/redux/slices/account.ts
+++ b/src/client/redux/slices/account.ts
@@ -1,37 +1,41 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
-export type AccountState = {
-  userId?: number;
-  username?: string;
-  role?: string;
+// Before a user is logged in, all fields are potentially undefined
+export type LoggedOutAccountState = {
+  userId: undefined;
+  username: undefined;
+  role: undefined;
 };
 
-const initialState: AccountState = {
+// Once a user is logged in, their account state must have all fields defined
+export type LoggedInAccountState = {
+  userId: number;
+  username: string;
+  role: string;
+};
+
+// The AccountState can either be in the logged out state or the logged in state
+export type AccountState = LoggedOutAccountState | LoggedInAccountState;
+
+const initialState: LoggedOutAccountState = {
   userId: undefined,
   username: undefined,
   role: undefined,
 };
 
-type LogInAction = PayloadAction<{
-  userId: number;
-  username: string;
-  role: string;
-}>;
+type LogInAction = PayloadAction<LoggedInAccountState>;
 
 const accountSlice = createSlice({
   name: 'account',
   initialState,
   reducers: {
     logIn: (state, action: LogInAction) => {
-      state.userId = action.payload.userId;
-      state.username = action.payload.username;
-      state.role = action.payload.role;
+      const { userId, username, role } = action.payload;
+      return { userId, username, role }; // return new state instead of mutating
     },
-    logOut: (state) => {
-      state.userId = undefined;
-      state.username = undefined;
-      state.role = undefined;
+    logOut: () => {
+      return initialState; // return the initialState directly
     },
   },
 });


### PR DESCRIPTION

By making the properties of 'AccountState' non-nullable, we enforce a stricter type check. This change avoids potential runtime errors by ensuring that once a user logs in, their 'userId', 'username', and 'role' must be defined. TypeScript's strict typing is now effectively leveraged to prevent a logged-in account state from missing critical user information.

This adjustment is not only about enforcing stricter type safety but also about supporting better state management practices within the Redux slice. It reflects a clearer understanding that once the user is logged in, the system should be confident about the presence of these fields without needing to check if they exist or are undefined.

This refactoring applies to scenarios where it is guaranteed that certain fields should definitely be populated, narrowing down the possible states of the application and simplifying the reasoning about the state at any point in time. It is assumed this holds true for the system this slice is designed for.
