### PR TITLE
Refactor `useMobileView` Hook to Include Semantic Name and Inline Documentation

### DIFF
--- a/src/client/hooks/useIsMobileWidth.ts
+++ b/src/client/hooks/useIsMobileWidth.ts
@@ -1,6 +1,10 @@
 import useInnerWidth from './useInnerWidth';
 
-export default (): boolean => {
+/**
+ * Hook for determining if the current view is a mobile view based on the inner width.
+ * @returns {boolean} True if the width of the window is less than 1024 pixels, indicating a mobile view.
+ */
+export default function useMobileView(): boolean {
   const width = useInnerWidth();
   return width < 1024;
 };


### PR DESCRIPTION

The `useMobileView` hook, previously an anonymous default export, now has a significant name and inline documentation has been added for clarity. Naming the hook improves the readability of the code, making it easier to understand at a glance and aids in maintainability. Furthermore, inline documentation provides developers with a quick understanding of the hook's purpose and usage without requiring deep dives into the implementation details.
