### PR TITLE
Replace hardcoded SVG dimensions in 'BackgroundSvg' with props for flexibility

### DIFF
--- a/src/client/components/TeamPage/TeamBanner/TeamBanner.tsx
+++ b/src/client/components/TeamPage/TeamBanner/TeamBanner.tsx
@@ -1,4 +1,5 @@
-import type { FunctionComponent } from 'react';
+```typescript
+import type { FunctionComponent, SVGProps } from 'react';
 import React from 'react';
 import Button, { ButtonSize } from '../../Button/Button';
 import styles from './TeamBanner.scss';
@@ -7,8 +8,13 @@ import BannerImg2 from './BannerImg2.jpg';
 import BannerImg3 from './BannerImg3.jpg';
 import BannerImg4 from './BannerImg4.jpg';
 
-const BackgroundSvg: FunctionComponent = () => (
-  <svg width="979" height="261" viewBox="0 0 979 261" fill="none" xmlns="http://www.w3.org/2000/svg">
+interface BackgroundSvgProps extends SVGProps<SVGSVGElement> {
+  width?: string | number;
+  height?: string | number,
+}
+
+const BackgroundSvg: FunctionComponent<BackgroundSvgProps> = ({ width = "979", height = "261", ...props }) => (
+  <svg width={width} height={height} viewBox="0 0 979 261" fill="none" {...props} xmlns="http://www.w3.org/2000/svg">
     <g opacity="0.6" filter="url(#filter0_f_57_5070)">
       <path d="M238.458 758.661C69.8249 604.081 45.3189 356.37 183.723 205.384C322.126 54.3983 571.029 57.3123 739.662 211.893C908.296 366.473 932.802 614.184 794.398 765.17C601.962 438.939 407.092 913.242 238.458 758.661Z" fill="url(#paint0_linear_57_5070)" />
     </g>
@@ -62,3 +68,4 @@ const PortfolioBanner: FunctionComponent = () => (
 );
 
 export default PortfolioBanner;
+```


### PR DESCRIPTION

The 'BackgroundSvg' component currently has hardcoded dimensions, which limit its reusability. By introducing optional width and height props with default values, we can make the component more flexible and allow it to be used in different contexts where dimensions may vary. This change preserves backward compatibility while enhancing the component's adaptability.
