### PR TITLE
Rename noNavBarRoutes to NO_NAV_BAR_ROUTES for better coding convention adherence

### DIFF
--- a/src/client/components/ShowNavBar/ShowNavBar.tsx
+++ b/src/client/components/ShowNavBar/ShowNavBar.tsx
@@ -5,7 +5,7 @@ interface IProps {
   children: React.JSX.Element;
 }
 
-const noNavBarRoutes = new Set([
+const NO_NAV_BAR_ROUTES = new Set([
   '/login',
   '/login/forgot-password',
   '/login/reset-password',
@@ -16,7 +16,7 @@ const ShowNavBar = ({ children }: IProps): React.JSX.Element => {
   const locationPath = useLocation();
 
   useEffect(() => {
-    setShowNavBar(!noNavBarRoutes.has(locationPath.pathname));
+    setShowNavBar(!NO_NAV_BAR_ROUTES.has(locationPath.pathname));
   }, [locationPath]);
 
   return (


### PR DESCRIPTION
Standard practice for constant collections, such as sets, arrays, and objects, especially when they are used for configuration-like purposes, is to use uppercase with underscores to denote their immutability and global scope. The change will improve readability and maintainability by aligning with common coding conventions in the JavaScript/TypeScript community.