### PR TITLE
Refactor XIcon functional component to use proper React.FC type with Props

### DIFF
--- a/src/client/static/svgs/XIcon.tsx
+++ b/src/client/static/svgs/XIcon.tsx
@@ -1,7 +1,9 @@
 import type { FunctionComponent } from 'react';
 import React from 'react';
 
-const XIcon: FunctionComponent = () => (
+interface Props {}
+
+const XIcon: FunctionComponent<Props> = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M6 18L18 6M6 6L18 18" stroke="black" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
   </svg>


### PR DESCRIPTION

While the XIcon component does not use any props, it is best practice to define the type of props it could accept, even if it's an empty object. This change allows for better type inference and makes the code's intention clearer for future developers who might work on this component.

By explicitly mentioning `Props` in the React.FC type, we ensure the component is typed correctly and consistently with the expected patterns in a TypeScript + React codebase.
