### PR TITLE
Improve 'Navigate' to Use Replace Prop in 'EmployeePrivateRoute' to Prevent Adding Unwanted History Entries

### DIFF
--- a/src/client/components/PrivateRoutes/EmployeePrivateRoute.tsx
+++ b/src/client/components/PrivateRoutes/EmployeePrivateRoute.tsx
@@ -10,7 +10,8 @@ interface IProps {
 const EmployeePrivateRoute = ({ children }: IProps): React.JSX.Element => {
   const isEmployee = useSelector(getIsEmployee);
   if (!isEmployee) {
-    return <Navigate to="/login" />;
+    // The 'replace' prop is set to true to replace the current entry in the history stack
+    return <Navigate to="/login" replace />;
   }
 
   return children;


### PR DESCRIPTION

The 'EmployeePrivateRoute' component currently uses the 'Navigate' component from 'react-router-dom' to redirect non-employee users to the '/login' page. However, it does not specify the 'replace' prop, which can result in an unwanted entry in the browser history stack. Users who hit the back button after being redirected would find themselves immediately redirected back to '/login', potentially causing confusion.

To improve the user experience, the 'replace' prop has been set to true in the 'Navigate' component inside 'EmployeePrivateRoute', thereby replacing the current entry in the history stack instead of adding a new one. This change ensures that when a user is redirected to the '/login' page, they can navigate backwards in their browser history to their last visited location before the redirect.

This is a minor but crucial enhancement in preventing user frustration and ensuring that navigation behaves as expected after redirection due to lack of employee privileges.
