### PR TITLE
Improve 'CallToAction' component structure by extracting text content into constants

### DIFF
--- a/src/client/components/CallToAction/CallToAction.tsx
+++ b/src/client/components/CallToAction/CallToAction.tsx
@@ -3,19 +3,21 @@ import type { FunctionComponent } from 'react';
 import Button, { ButtonSize } from '../Button/Button';
 import style from './CallToAction.scss';
 
+// Constants for text contents
+const HEADER_TEXT = 'We make your business shine';
+const BODY_TEXT = 'Book a call to see how Perspective Design can help elevate your company&#39;s designs to the next level.';
+const BUTTON_TEXT = 'Explore more';
+const BUTTON_LINK = '/contact-us';
+
 const CallToAction: FunctionComponent = () => (
   <div className={style.ctaContainer}>
-    <h2>We make your business shine</h2>
-    <p>
-      Book a call to see how Perspective Design
-      can help elevate your company&#39;s designs
-      to the next level.
-    </p>
+    <h2>{HEADER_TEXT}</h2>
+    <p>{BODY_TEXT}</p>
     <Button
       size={ButtonSize.Large}
-      to="/contact-us"
+      to={BUTTON_LINK}
     >
-      Explore more
+      {BUTTON_TEXT}
     </Button>
   </div>
 );


### PR DESCRIPTION

Refactor: The 'CallToAction' component currently has hard-coded text which makes it less maintainable and harder to internationalize. I've extracted the text into constants outside the component which makes it easier to replace or translate the text in the future. This change improves maintainability and prepares the component for potential internationalization.

Motivation: A central place for strings allows for easier edits and localizations. This change sets a good practice that can be beneficial for scaling the application in terms of language support and maintainability.
