### PR TITLE
Optimize 'ShowNavBar' Hook Dependency for 'useEffect'

### DIFF
--- a/src/client/components/ShowNavBar/ShowNavBar.tsx
+++ b/src/client/components/ShowNavBar/ShowNavBar.tsx
@@ -13,11 +13,11 @@ const noNavBarRoutes = new Set([
 
 const ShowNavBar = ({ children }: IProps): React.JSX.Element => {
   const [showNavBar, setShowNavBar] = useState(true);
-  const locationPath = useLocation();
+  const { pathname } = useLocation();
 
   useEffect(() => {
-    setShowNavBar(!noNavBarRoutes.has(locationPath.pathname));
-  }, [locationPath]);
+    setShowNavBar(!noNavBarRoutes.has(pathname));
+  }, [pathname]);
 
   return (
     <div>{showNavBar && children}</div>


### PR DESCRIPTION

Currently, ShowNavBar component updates its state based on the entire 'location' object returned from useLocation(), which potentially contains more information than necessary for the effect to run. By only tracking the 'pathname' field, which is the actual determinant for setShowNavBar, it ensures the effect runs only when pathname changes. This reduces unnecessary re-renders and avoids potential bugs related to unrelated location changes.

This change refactors the ShowNavBar component to directly destructure and use 'pathname' as a dependency in the useEffect hook, which is more efficient and clearer in intent.
