### PR TITLE
Added debounce mechanism to 'useWindowWidth' hook for performance optimization

### DIFF
--- a/src/client/hooks/useInnerWidth.ts
+++ b/src/client/hooks/useInnerWidth.ts
@@ -1,15 +1,27 @@
 import { useState, useEffect } from 'react';
 
-export default (): number => {
-  const [width, setWidth] = useState(window.innerWidth);
-
-  useEffect(() => {
-    const handleResize = (): void => {
-      setWidth(window.innerWidth);
+function debounce(fn: Function, delay: number) {
+    let timeoutId: NodeJS.Timeout | null = null;
+    return function (...args: any[]) {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+        timeoutId = setTimeout(() => fn(...args), delay);
     };
-    window.addEventListener('resize', handleResize);
-    return (): void => window.removeEventListener('resize', handleResize);
-  }, []);
+}
 
-  return width;
+export default function useWindowWidth(): number {
+    const [width, setWidth] = useState(window.innerWidth);
+
+    useEffect(() => {
+        const handleResize = (): void => {
+            setWidth(window.innerWidth);
+        };
+        const debouncedHandleResize = debounce(handleResize, 100);
+
+        window.addEventListener('resize', debouncedHandleResize);
+        return (): void => window.removeEventListener('resize', debouncedHandleResize);
+    }, []);
+
+    return width;
 };


### PR DESCRIPTION

The 'useWindowWidth' React hook is updated to include a debounce mechanism. This prevents the 'handleResize' function from being called excessively on rapid window resizes, which can lead to performance issues, especially in complex applications. I have added a 100ms debounce interval, which could be adjusted according to project needs.
