### PR TITLE
Refactor ResourcesPage component to include Helmet metadata as a reusable component

### DIFF
--- a/src/client/pages/ResourcesPage/ResourcesPage.tsx
+++ b/src/client/pages/ResourcesPage/ResourcesPage.tsx
@@ -4,17 +4,28 @@ import { Helmet } from 'react-helmet';
 import ResourcesBanner from '../../components/ResourcesPage/ResourcesBanner/ResourcesBanner';
 import ResourcesPanels from '../../components/ResourcesPage/ResourcesPanels/ResourcesPanels';
 
+const PageHelmet: FunctionComponent<{
+  title: string;
+  charSet: string;
+  link: string;
+  description: string;
+}> = ({ title, charSet, link, description }) => (
+  <Helmet>
+    <meta charSet={charSet} />
+    <title>{title}</title>
+    <link rel="canonical" href={link} />
+    <meta name="description" content={description} />
+  </Helmet>
+);
+
 const ResourcesPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Resources - Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/resources" />
-      <meta
-        name="description"
-        content="Portfolio of projects done by Sunny Software LLC"
-      />
-    </Helmet>
+    <PageHelmet
+      title="Resources - Sunny Software"
+      charSet="utf-8"
+      link="https://sunnysoftware.dev/resources"
+      description="Portfolio of projects done by Sunny Software LLC"
+    />
     <ResourcesBanner />
     <ResourcesPanels />
   </div>


### PR DESCRIPTION

Instead of writing the Helmet metadata directly inside the ResourcesPage component, it can be refactored into a separate reusable component. This improves modularity, readability, and allows for easier maintenance if the metadata needs to change or be reused across other pages. By extracting the metadata into its own component, named `PageHelmet`, we enhance the reusability and separation of concerns within the application's components.

The proposed change involves creating a new `PageHelmet` component that accepts props for title, charSet, link, and description, and then using this new component in the `ResourcesPage` component. This refactoring makes the ResourcesPage cleaner and prepares for any future pages that might also utilize the `PageHelmet`.
