### PR TITLE
Refactor MethodologyPage to Use React.FC Typing and Define Metadata as Constant

### DIFF
--- a/src/client/pages/MethodologyPage/MethodologyPage.tsx
+++ b/src/client/pages/MethodologyPage/MethodologyPage.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
-import type { FunctionComponent } from 'react';
 import { Helmet } from 'react-helmet';
 import MethodologyBanner from '../../components/MethodologyPage/MethodologyBanner/MethodologyBanner';
 import MethodologyFullList from '../../components/MethodologyPage/MethodologyFullList/MethodologyFullList';
 import MethodologyBenefits from '../../components/MethodologyPage/MethodologyBenefits/MethodologyBenefits';
 import MethodologyNeedHelp from '../../components/MethodologyPage/MethodologyNeedHelp/MethodologyNeedHelp';
 
-const MethodologyPage: FunctionComponent = () => (
+const pageMetadata = {
+  charset: "utf-8",
+  title: "Methodology-Sunny Software",
+  canonicalLink: "https://sunnysoftware.dev/methodology",
+  description: "The methodology of Sunny Software LLC"
+};
+
+const MethodologyPage: React.FC = () => (
   <div>
     <Helmet>
-      <meta charSet="utf-8" />
-      <title>Methodology-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/methodology" />
+      <meta charSet={pageMetadata.charset} />
+      <title>{pageMetadata.title}</title>
+      <link rel="canonical" href={pageMetadata.canonicalLink} />
       <meta
         name="description"
-        content="The methodology of Sunny Software LLC"
+        content={pageMetadata.description}
       />
     </Helmet>
     <MethodologyBanner />


### PR DESCRIPTION

The current implementation of the MethodologyPage component uses the "FunctionComponent" type imported specifically for the component declaration. In React, it is a common and concise practice to directly use "React.FC" for component typing. This refactoring change makes the code cleaner and aligns with common React patterns.

Additionally, the metadata within the Helmet component is hardcoded within the JSX. This refactoring extracts it to a constant outside of the component to increase readability and maintainability. Should the metadata need to be updated or localized in the future, having it defined in a separate constant makes these changes easier to manage.
