### PR TITLE
Optimize StatisticsBar Component by Using React.memo for Pure Components

### DIFF
--- a/src/client/components/TestimonialsPage/StatisticsBar/StatisticsBar.tsx
+++ b/src/client/components/TestimonialsPage/StatisticsBar/StatisticsBar.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { memo } from 'react';
 import styles from './StatisticsBar.scss';
 
 interface Statistic {
@@ -14,7 +14,7 @@ const statistics: Statistic[] = [
   { value: '95%', description: 'Positive reviews' },
 ];
 
-const StatisticsBar: FunctionComponent = () => (
+const StatisticsBar: FunctionComponent = memo(() => (
   <div className={styles.barContainer}>
     {statistics.map(stat => (
       <div key={stat.description} className={styles.statistic}>
@@ -23,6 +23,6 @@ const StatisticsBar: FunctionComponent = () => (
       </div>
     ))}
   </div>
-);
+));
 
 export default StatisticsBar;


### PR DESCRIPTION

Refactoring StatisticsBar component to utilize React.memo to prevent unnecessary re-renders. As StatisticsBar is a pure functional component that relies on constant props (the `statistics` array), wrapping it with React.memo can help improve performance by preventing re-renders when parent components change state, but the props of StatisticsBar do not.

This change is particularly beneficial in larger applications where the component might be a child in a deeply nested structure, and it leverages the optimizations available in React for functional components to avoid wasteful DOM updates.
