### PR TITLE
Refactor ServicesPage to Include Helmet Setup in a Separate Function

### DIFF
--- a/src/client/pages/ServicesPage/ServicesPage.tsx
+++ b/src/client/pages/ServicesPage/ServicesPage.tsx
@@ -5,17 +5,22 @@ import ServicesPageBanner from '../../components/ServicesPage/ServicesPageBanner
 import FullServicesList from '../../components/ServicesPage/FullServicesList/FullServicesList';
 import ServicesNeedHelp from '../../components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp';
 
+// Encapsulate Helmet rendering logic
+const renderHelmet = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Services-Sunny Software</title>
+    <link rel="canonical" href="https://sunnysoftware.dev/services" />
+    <meta
+      name="description"
+      content="Information on services offered by Sunny Software LLC"
+    />
+  </Helmet>
+);
+
 const ServicesPage: FunctionComponent = () => (
   <div>
-    <Helmet>
-      <meta charSet="utf-8" />
-      <title>Services-Sunny Software</title>
-      <link rel="canonical" href="https://sunnysoftware.dev/services" />
-      <meta
-        name="description"
-        content="Information on services offered by Sunny Software LLC"
-      />
-    </Helmet>
+    {renderHelmet()}
     <ServicesPageBanner />
     <FullServicesList />
     <ServicesNeedHelp />


### PR DESCRIPTION

To enhance readibility and maintainability of the ServicesPage component, the meta tags setup for Helmet is moved to a separate function named "renderHelmet". This encapsulates the Helmet configuration, making the ServicesPage component cleaner and more focused on its primary responsibility of layout composition. This small refactoring is beneficial as it abstracts away the details of the head setup, allowing for potential reuse and easier updates in the future.
