### PR TITLE
Refactor 'StatisticsBar' to Include a Subcomponent for Statistic Item Display

### DIFF
--- a/src/client/components/TestimonialsPage/StatisticsBar/StatisticsBar.tsx
+++ b/src/client/components/TestimonialsPage/StatisticsBar/StatisticsBar.tsx
@@ -7,6 +7,17 @@ interface Statistic {
   description: string;
 }
 
+interface StatisticItemProps {
+  stat: Statistic;
+}
+
+const StatisticItem: FunctionComponent<StatisticItemProps> = ({ stat }) => (
+  <div key={stat.description} className={styles.statistic}>
+    <h2>{stat.value}</h2>
+    <p>{stat.description}</p>
+  </div>
+);
+
 const statistics: Statistic[] = [
   { value: '15+', description: 'Years of experience' },
   { value: '1K+', description: 'Happy Customers' },
@@ -16,11 +27,8 @@ const statistics: Statistic[] = [
 
 const StatisticsBar: FunctionComponent = () => (
   <div className={styles.barContainer}>
-    {statistics.map(stat => (
-      <div key={stat.description} className={styles.statistic}>
-        <h2>{stat.value}</h2>
-        <p>{stat.description}</p>
-      </div>
+    {statistics.map((stat) => (
+      <StatisticItem key={stat.description} stat={stat} />
     ))}
   </div>
 );


### PR DESCRIPTION

The 'StatisticsBar' function component in our React codebase currently maps over an array of statistics and directly returns the corresponding JSX inside the map callback. This PR introduces a subcomponent called 'StatisticItem' that encapsulates the rendering logic for an individual statistic. This change enhances the reusability and readability of the code, making it clearer what each part of the statistics bar does. Additionally, this refactoring enables easier maintenance and potential extension of the rendering logic for a single statistic item in the future.
