### PR TITLE
Optimize 'AccordianPanel' Toggle Function by Removing Dependency Array

### DIFF
--- a/src/client/components/AccordianPanel/AccordianPanel.tsx
+++ b/src/client/components/AccordianPanel/AccordianPanel.tsx
@@ -7,12 +7,14 @@ type AccordianPanelProps = {
   answer: string;
 };
 
-const AccordianPanel: FunctionComponent<AccordianPanelProps>
- = ({ question, answer }) => {
+const AccordianPanel: FunctionComponent<AccordianPanelProps> = ({ question, answer }) => {
    const [isOpen, setIsOpen] = useState(false);
+
+   // Toggle the visibility of the answer panel
    const togglePanel = useCallback(() => {
-     setIsOpen(!isOpen);
-   }, [isOpen]);
+     setIsOpen(isOpen => !isOpen);
+   }, []); // Removed dependency array
+
    return (
      <div className={styles.accordianPanelContainer}>
        <div className={styles.accordianQuestion} onClick={togglePanel}>
@@ -25,6 +27,6 @@ const AccordianPanel: FunctionComponent<AccordianPanelProps>
        {isOpen && <p className={styles.accordianAnswer}>{answer}</p>}
      </div>
    );
- };
+};
 
 export default AccordianPanel;


### PR DESCRIPTION

The dependency array in the `useCallback` hook for the 'togglePanel' function inside the 'AccordianPanel' component is unnecessary as the state setter function from `useState` is stable and does not need to be included in the dependencies. This change removes the dependency array, which simplifies the component and removes an unnecessary re-creation of the toggle function. The overall functionality of the 'AccordianPanel' component remains intact with improved slightly performance.
