### PR TITLE
Rename SCSS class import to follow CamelCase convention in ServicesNeedHelp component

### DIFF
--- a/src/client/components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp.tsx
+++ b/src/client/components/ServicesPage/ServicesNeedHelp/ServicesNeedHelp.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'react';
 import React from 'react';
 import Button, { ButtonSize, ButtonVariant } from '../../Button/Button';
-import styles from './ServicesNeedHelp.scss';
+import styles from './ServicesNeedHelp.module.scss';
 
 const ServicesNeedHelp: FunctionComponent = () => (
   <div className={styles.container}>


### PR DESCRIPTION

The SCSS class import name in the ServicesNeedHelp component is currently using snake_case, which is not consistent with TypeScript and React common naming conventions that prefer CamelCase. Updating the variable name improves consistency and readability of the code. This change only affects the local import name and has no impact on the actual CSS class names defined in the SCSS file. 

This is a non-breaking, stylistic refactor that will make our codebase more consistent and aligned with industry practices.
