### PR TITLE
Rename 'setterCallback' parameter to 'setValue' for clarity in useChangeHandler hook

### DIFF
--- a/src/client/hooks/useChangeHandler.ts
+++ b/src/client/hooks/useChangeHandler.ts
@@ -2,20 +2,20 @@ import { useCallback } from 'react';
 import type { ChangeEvent } from 'react';
 import logger from '../../server/logger';
 
-type SetterCallback = (value: string) => void;
+type SetValue = (value: string) => void;
 type ChangeHandler = (e: ChangeEvent<HTMLSelectElement>) => void;
 
-const useChangeHandler = (setterCallback: SetterCallback): ChangeHandler => {
+const useChangeHandler = (setValue: SetValue): ChangeHandler => {
   const changeHandler: ChangeHandler = (e) => {
     e.preventDefault();
     const { target } = e;
     if (target instanceof HTMLSelectElement) {
-      setterCallback(e.target.value);
+      setValue(target.value);
     } else {
       logger.info('type error in TimeDropdown: handleValueChange');
     }
   };
-  return useCallback(changeHandler, [setterCallback]);
+  return useCallback(changeHandler, [setValue]);
 };
 
 export default useChangeHandler;


### PR DESCRIPTION

The parameter name 'setterCallback' in the 'useChangeHandler' hook is renamed to 'setValue' to improve understanding and readability of the code. 'setValue' more clearly represents its purpose as a function that sets a given value, aligning with common naming conventions for setter functions in React state management.

This change is valuable because it makes the code more intuitive for new developers or for revisiting the code after some time. With this change, the 'useChangeHandler' hook becomes clearer, as it signals to the developer that this parameter is used to set a value in a stateful component or hook.
