### PR TITLE
Rename Import from 'MangageProjects' to 'ManageProjects' for Consistency and Correctness

### DIFF
--- a/src/client/pages/AdminPortal/AdminPortalPage.tsx
+++ b/src/client/pages/AdminPortal/AdminPortalPage.tsx
@@ -6,7 +6,7 @@ import EmployeeWorkCalendars from '../../components/EmployeeWorkCalendars/Employ
 import RegistrationForm from '../../components/RegistrationForm/RegistrationForm';
 import ManageUsers from '../../components/ManageUsers/ManageUsers';
 import ResetPassword from '../../components/ResetPassword/ResetPassword';
-import ManageProjects from '../../components/MangageProjects/ManageProjects';
+import ManageProjects from '../../components/ManageProjects/ManageProjects';
 
 const AdminPortalPage: FunctionComponent = () => (
   <div>


### PR DESCRIPTION

While reviewing the TypeScript file for the AdminPortalPage component, I noticed the import statement for the `ManageProjects` component has a typo in the directory name. It is currently imported from `../../components/MangageProjects/ManageProjects`, which should be `../../components/ManageProjects/ManageProjects`. This change ensures consistency and correctness in the codebase. Correct naming conventions are critical for maintainability and readability of the code. This is a straightforward fix but an important one as it might lead to module resolution errors or confusion among developers working on the project.

This refactor corrects the directory name in the import statement to match the naming convention used throughout the project and to ensure the import path is accurate.
