### PR TITLE
Refactor navigation logic in 'ForgotPasswordPage' to use useEffect hook

### DIFF
--- a/src/client/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/src/client/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import type { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import logo from '../../static/images/Logo.png';
 import loginPhoto from '../../static/images/LoginPhoto.png';
@@ -12,9 +11,12 @@ import styles from './ForgotPasswordPage.scss';
 const ForgotPasswordPage: FunctionComponent = () => {
   const navigate = useNavigate();
   const loggedIn = useSelector(getLoggedIn);
-  if (loggedIn) {
-    navigate('/');
-  }
+
+  useEffect(() => {
+    if (loggedIn) {
+      navigate('/');
+    }
+  }, [loggedIn, navigate]);
 
   return (
     <div className={styles.pageContainer}>


### PR DESCRIPTION

Moving the redirection logic for logged-in users in the `ForgotPasswordPage` component into a `useEffect` hook to avoid possible bugs with navigating during rendering.

The current code performs navigation in the body of the component which can potentially lead to issues if the navigation action is performed during the rendering phase. By moving the logic into a `useEffect` hook, the navigation will only be triggered after the component has been mounted, avoiding any unintended side effects and adhering to best practices for side effects in React components.
