### PR TITLE
Renamed 'backgroundSvg' to 'BackgroundSVG' for React Component Naming Conventions

### DIFF
--- a/src/client/components/CareersPage/CareersBanner/CareersBanner.tsx
+++ b/src/client/components/CareersPage/CareersBanner/CareersBanner.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Button, { ButtonSize } from '../../Button/Button';
 import styles from './CareersBanner.scss';
 
-const backgroundSvg = (
+const BackgroundSVG = (
   <svg width="979" height="261" viewBox="0 0 979 261" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g opacity="0.6" filter="url(#filter0_f_57_5070)">
       <path d="M238.458 758.661C69.8249 604.081 45.3189 356.37 183.723 205.384C322.126 54.3983 571.029 57.3123 739.662 211.893C908.296 366.473 932.802 614.184 794.398 765.17C601.962 438.939 407.092 913.242 238.458 758.661Z" fill="url(#paint0_linear_57_5070)" />
@@ -35,7 +35,7 @@ const CareersBanner: FunctionComponent = () => (
         Join our team
       </Button>
     </div>
-    {backgroundSvg}
+    {BackgroundSVG}
   </div>
 );
 


### PR DESCRIPTION

The name 'backgroundSvg' implies that the variable is a regular JavaScript variable when, in fact, it represents a React component. In React, component names should start with a capital letter. This change renames 'backgroundSvg' to 'BackgroundSVG' to adhere to the commonly accepted React naming conventions. Properly naming components improves readability and understanding of the code structure for future developers.
