### PR TITLE
Optimized 'togglePanel' Function in AccordianPanel Without Dependency Array

### DIFF
--- a/src/client/components/AccordianPanel/AccordianPanel.tsx
+++ b/src/client/components/AccordianPanel/AccordianPanel.tsx
@@ -7,24 +7,27 @@ type AccordianPanelProps = {
   answer: string;
 };
 
-const AccordianPanel: FunctionComponent<AccordianPanelProps>
- = ({ question, answer }) => {
-   const [isOpen, setIsOpen] = useState(false);
-   const togglePanel = useCallback(() => {
-     setIsOpen(!isOpen);
-   }, [isOpen]);
-   return (
-     <div className={styles.accordianPanelContainer}>
-       <div className={styles.accordianQuestion} onClick={togglePanel}>
-         <h3>{question}</h3>
-         <div className={styles.panelArrow}>
-           {'>'}
-         </div>
-       </div>
-       <div className={styles.accordianDivider} />
-       {isOpen && <p className={styles.accordianAnswer}>{answer}</p>}
-     </div>
-   );
- };
+const AccordianPanel: FunctionComponent<AccordianPanelProps> = ({ question, answer }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Using the functional update form to negate the previous state
+  // removes the necessity of dependency array for useCallback
+  const togglePanel = useCallback(() => {
+    setIsOpen(open => !open);
+  }, []);
+
+  return (
+    <div className={styles.accordianPanelContainer}>
+      <div className={styles.accordianQuestion} onClick={togglePanel}>
+        <h3>{question}</h3>
+        <div className={styles.panelArrow}>
+          {'>'}
+        </div>
+      </div>
+      <div className={styles.accordianDivider} />
+      {isOpen && <p className={styles.accordianAnswer}>{answer}</p>}
+    </div>
+  );
+};
 
 export default AccordianPanel;


### PR DESCRIPTION

The current implementation of 'togglePanel' uses a useCallback hook with 'isOpen' as a dependency, which causes the function 'togglePanel' to be re-created when 'isOpen' changes. I have refactored 'togglePanel' to use a functional update form of 'setIsOpen', which allows us to remove the dependency array completely. This optimizes the component by preventing unnecessary recreations of the 'togglePanel' function while maintaining the same functionality.

Specifically, by utilizing the functional update form of the state updater function, we pass a function to 'setIsOpen' which receives the previous value of 'isOpen' as an argument and returns the negated value, hence removing the need to include 'isOpen' in the callback's dependencies. This is a valuable performance optimization for this functional component.
